### PR TITLE
Start and End callback methods (optional) to visitors. Related to #19

### DIFF
--- a/src/main/java/org/repodriller/CommitVisitorIterator.java
+++ b/src/main/java/org/repodriller/CommitVisitorIterator.java
@@ -7,14 +7,15 @@ import org.apache.log4j.Logger;
 import org.repodriller.domain.Commit;
 import org.repodriller.persistence.PersistenceMechanism;
 import org.repodriller.scm.CommitVisitor;
+import org.repodriller.scm.RequiresCommitCounter;
 import org.repodriller.scm.SCMRepository;
 
-public class CommitVisitorPersistenceMechanisMap {
+public class CommitVisitorIterator {
 
 	private Map<CommitVisitor, PersistenceMechanism> visitors;
 	private Logger log;
 	
-	public CommitVisitorPersistenceMechanisMap(Logger log) {
+	public CommitVisitorIterator(Logger log) {
 		this.log = log;
 		visitors = new HashMap<CommitVisitor, PersistenceMechanism>();
 	}
@@ -41,6 +42,9 @@ public class CommitVisitorPersistenceMechanisMap {
 
 			try {
 				log.info("-> Processing " + commit.getHash() + " with " + visitor.name());
+				if (visitor instanceof RequiresCommitCounter) {
+					((RequiresCommitCounter) visitor).count(commit);
+				}
 				visitor.process(repo, commit, writer);
 			} catch (Exception e) {
 				log.error("error processing #" + commit.getHash() + " in " + repo.getPath() + 

--- a/src/main/java/org/repodriller/CommitVisitorIterator.java
+++ b/src/main/java/org/repodriller/CommitVisitorIterator.java
@@ -7,7 +7,6 @@ import org.apache.log4j.Logger;
 import org.repodriller.domain.Commit;
 import org.repodriller.persistence.PersistenceMechanism;
 import org.repodriller.scm.CommitVisitor;
-import org.repodriller.scm.RequiresCommitCounter;
 import org.repodriller.scm.SCMRepository;
 
 public class CommitVisitorIterator {
@@ -42,9 +41,6 @@ public class CommitVisitorIterator {
 
 			try {
 				log.info("-> Processing " + commit.getHash() + " with " + visitor.name());
-				if (visitor instanceof RequiresCommitCounter) {
-					((RequiresCommitCounter) visitor).count(commit);
-				}
 				visitor.process(repo, commit, writer);
 			} catch (Exception e) {
 				log.error("error processing #" + commit.getHash() + " in " + repo.getPath() + 

--- a/src/main/java/org/repodriller/CommitVisitorPersistenceMechanisMap.java
+++ b/src/main/java/org/repodriller/CommitVisitorPersistenceMechanisMap.java
@@ -1,0 +1,74 @@
+package org.repodriller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.repodriller.domain.Commit;
+import org.repodriller.persistence.PersistenceMechanism;
+import org.repodriller.scm.CommitVisitor;
+import org.repodriller.scm.SCMRepository;
+
+public class CommitVisitorPersistenceMechanisMap {
+
+	private Map<CommitVisitor, PersistenceMechanism> visitors;
+	private Logger log;
+	
+	public CommitVisitorPersistenceMechanisMap(Logger log) {
+		this.log = log;
+		visitors = new HashMap<CommitVisitor, PersistenceMechanism>();
+	}
+
+	void initializeVisitors(SCMRepository repo) {
+		visitors.forEach((visitor,writer) -> {
+			try {
+				log.info("-> Initializing visitor " + visitor.name());
+				visitor.initialize(repo, writer);
+			} catch (Exception e) {
+				log.error("error in " + repo.getPath() + 
+						"when initializing " + visitor.name() + ", error=" + e.getMessage(), e);
+			}
+		});
+	}
+
+	void processCommit(SCMRepository repo, Commit commit) {
+		visitors.forEach((visitor,writer) -> {
+			try {
+				log.info("-> Processing " + commit.getHash() + " with " + visitor.name());
+				visitor.process(repo, commit, writer);
+			} catch (Exception e) {
+				log.error("error processing #" + commit.getHash() + " in " + repo.getPath() + 
+						", processor=" + visitor.name() + ", error=" + e.getMessage(), e);
+			}
+		});
+	}
+	
+	void finalizeVisitors(SCMRepository repo) {
+		visitors.forEach((visitor,writer) -> {
+			try {
+				log.info("-> Finalizing visitor " + visitor.name());
+				visitor.finalize(repo, writer);
+			} catch (Exception e) {
+				log.error("error in " + repo.getPath() + 
+						"when finalizing " + visitor.name() + ", error=" + e.getMessage(), e);
+			}
+		});
+	}
+	
+	void closeAllPersistence() {
+		for(PersistenceMechanism persist : visitors.values()) {
+			persist.close();
+		}
+	}
+
+	void printScript() {
+		for(CommitVisitor visitor : visitors.keySet()) {
+			log.info("- " + visitor.name() + " (" + visitor.getClass().getName() + ")");
+		}
+	}
+
+	public void put(CommitVisitor visitor, PersistenceMechanism writer) {
+		this.visitors.put(visitor, writer);
+	}
+	
+}

--- a/src/main/java/org/repodriller/CommitVisitorPersistenceMechanisMap.java
+++ b/src/main/java/org/repodriller/CommitVisitorPersistenceMechanisMap.java
@@ -20,7 +20,10 @@ public class CommitVisitorPersistenceMechanisMap {
 	}
 
 	void initializeVisitors(SCMRepository repo) {
-		visitors.forEach((visitor,writer) -> {
+		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
+			CommitVisitor visitor = entry.getKey();
+			PersistenceMechanism writer = entry.getValue();
+
 			try {
 				log.info("-> Initializing visitor " + visitor.name());
 				visitor.initialize(repo, writer);
@@ -28,11 +31,14 @@ public class CommitVisitorPersistenceMechanisMap {
 				log.error("error in " + repo.getPath() + 
 						"when initializing " + visitor.name() + ", error=" + e.getMessage(), e);
 			}
-		});
+		}
 	}
 
 	void processCommit(SCMRepository repo, Commit commit) {
-		visitors.forEach((visitor,writer) -> {
+		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
+			CommitVisitor visitor = entry.getKey();
+			PersistenceMechanism writer = entry.getValue();
+
 			try {
 				log.info("-> Processing " + commit.getHash() + " with " + visitor.name());
 				visitor.process(repo, commit, writer);
@@ -40,11 +46,14 @@ public class CommitVisitorPersistenceMechanisMap {
 				log.error("error processing #" + commit.getHash() + " in " + repo.getPath() + 
 						", processor=" + visitor.name() + ", error=" + e.getMessage(), e);
 			}
-		});
+		}
 	}
 	
 	void finalizeVisitors(SCMRepository repo) {
-		visitors.forEach((visitor,writer) -> {
+		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
+			CommitVisitor visitor = entry.getKey();
+			PersistenceMechanism writer = entry.getValue();
+
 			try {
 				log.info("-> Finalizing visitor " + visitor.name());
 				visitor.finalize(repo, writer);
@@ -52,7 +61,7 @@ public class CommitVisitorPersistenceMechanisMap {
 				log.error("error in " + repo.getPath() + 
 						"when finalizing " + visitor.name() + ", error=" + e.getMessage(), e);
 			}
-		});
+		}
 	}
 	
 	void closeAllPersistence() {

--- a/src/main/java/org/repodriller/RepositoryMining.java
+++ b/src/main/java/org/repodriller/RepositoryMining.java
@@ -16,7 +16,6 @@
 
 package org.repodriller;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.log4j.Logger;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
@@ -40,7 +40,7 @@ import com.google.common.collect.Lists;
 
 public class RepositoryMining {
 
-	private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+	private static final String DATE_FORMAT = "dd/MM/yyyy HH:mm:ss";
 	private static final Logger log = Logger.getLogger(RepositoryMining.class);
 
 	private List<SCMRepository> repos;
@@ -155,7 +155,7 @@ public class RepositoryMining {
 		log.info(
 				"Commit #" + commit.getHash() + 
 				" @ " + repo.getLastDir() +
-				" in " + SIMPLE_DATE_FORMAT.format(commit.getDate().getTime()) +
+				" in " + DateFormatUtils.format(commit.getDate().getTime(), DATE_FORMAT) +
 				" from " + commit.getAuthor().getName() + 
 				" with " + commit.getModifications().size() + " modifications");
 

--- a/src/main/java/org/repodriller/RepositoryMining.java
+++ b/src/main/java/org/repodriller/RepositoryMining.java
@@ -41,10 +41,10 @@ import com.google.common.collect.Lists;
 public class RepositoryMining {
 
 	private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
-	private static Logger log = Logger.getLogger(RepositoryMining.class);
+	private static final Logger log = Logger.getLogger(RepositoryMining.class);
 
 	private List<SCMRepository> repos;
-	private CommitVisitorPersistenceMechanisMap visitors;
+	private CommitVisitorIterator visitors;
 	private CommitRange range;
 	private int threads;
 	private boolean reverseOrder;
@@ -52,7 +52,7 @@ public class RepositoryMining {
 	
 	public RepositoryMining() {
 		repos = new ArrayList<SCMRepository>();
-		visitors = new CommitVisitorPersistenceMechanisMap(log);
+		visitors = new CommitVisitorIterator(log);
 		filters = Arrays.asList((CommitFilter) new NoFilter());
 		this.threads = 1;
 	}

--- a/src/main/java/org/repodriller/RepositoryMining.java
+++ b/src/main/java/org/repodriller/RepositoryMining.java
@@ -90,11 +90,43 @@ public class RepositoryMining {
 	public void mine() {
 		
 		for(SCMRepository repo : repos) {
+			initializeVisitors(repo);
 			processRepos(repo);
+			finalizeVisitors(repo);
 		}
 		closeAllPersistence();
 		printScript();
 		
+	}
+
+	private void initializeVisitors(SCMRepository repo) {
+		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
+			CommitVisitor visitor = entry.getKey();
+			PersistenceMechanism writer = entry.getValue();
+
+			try {
+				log.info("-> Initializing visitor " + visitor.name());
+				visitor.initialize(repo, writer);
+			} catch (Exception e) {
+				log.error("error in " + repo.getPath() + 
+						"when initializing " + visitor.name() + ", error=" + e.getMessage(), e);
+			}
+		}
+	}
+
+	private void finalizeVisitors(SCMRepository repo) {
+		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
+			CommitVisitor visitor = entry.getKey();
+			PersistenceMechanism writer = entry.getValue();
+
+			try {
+				log.info("-> Finalizing visitor " + visitor.name());
+				visitor.finalize(repo, writer);
+			} catch (Exception e) {
+				log.error("error in " + repo.getPath() + 
+						"when finalizing " + visitor.name() + ", error=" + e.getMessage(), e);
+			}
+		}
 	}
 
 	private void processRepos(SCMRepository repo) {

--- a/src/main/java/org/repodriller/RepositoryMining.java
+++ b/src/main/java/org/repodriller/RepositoryMining.java
@@ -20,9 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -42,10 +40,11 @@ import com.google.common.collect.Lists;
 
 public class RepositoryMining {
 
-	private List<SCMRepository> repos;
-	private Map<CommitVisitor, PersistenceMechanism> visitors;
-	
+	private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
 	private static Logger log = Logger.getLogger(RepositoryMining.class);
+
+	private List<SCMRepository> repos;
+	private CommitVisitorPersistenceMechanisMap visitors;
 	private CommitRange range;
 	private int threads;
 	private boolean reverseOrder;
@@ -53,7 +52,7 @@ public class RepositoryMining {
 	
 	public RepositoryMining() {
 		repos = new ArrayList<SCMRepository>();
-		visitors = new HashMap<CommitVisitor, PersistenceMechanism>();
+		visitors = new CommitVisitorPersistenceMechanisMap(log);
 		filters = Arrays.asList((CommitFilter) new NoFilter());
 		this.threads = 1;
 	}
@@ -90,43 +89,13 @@ public class RepositoryMining {
 	public void mine() {
 		
 		for(SCMRepository repo : repos) {
-			initializeVisitors(repo);
+			visitors.initializeVisitors(repo);
 			processRepos(repo);
-			finalizeVisitors(repo);
+			visitors.finalizeVisitors(repo);
 		}
-		closeAllPersistence();
+		visitors.closeAllPersistence();
 		printScript();
 		
-	}
-
-	private void initializeVisitors(SCMRepository repo) {
-		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
-			CommitVisitor visitor = entry.getKey();
-			PersistenceMechanism writer = entry.getValue();
-
-			try {
-				log.info("-> Initializing visitor " + visitor.name());
-				visitor.initialize(repo, writer);
-			} catch (Exception e) {
-				log.error("error in " + repo.getPath() + 
-						"when initializing " + visitor.name() + ", error=" + e.getMessage(), e);
-			}
-		}
-	}
-
-	private void finalizeVisitors(SCMRepository repo) {
-		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
-			CommitVisitor visitor = entry.getKey();
-			PersistenceMechanism writer = entry.getValue();
-
-			try {
-				log.info("-> Finalizing visitor " + visitor.name());
-				visitor.finalize(repo, writer);
-			} catch (Exception e) {
-				log.error("error in " + repo.getPath() + 
-						"when finalizing " + visitor.name() + ", error=" + e.getMessage(), e);
-			}
-		}
 	}
 
 	private void processRepos(SCMRepository repo) {
@@ -178,23 +147,15 @@ public class RepositoryMining {
 		
 		log.info("The following processors were executed:");
 		
-		for(CommitVisitor visitor : visitors.keySet()) {
-			log.info("- " + visitor.name() + " (" + visitor.getClass().getName() + ")");
-		}
-		
+		visitors.printScript();
 	}
 
-	private void closeAllPersistence() {
-		for(PersistenceMechanism persist : visitors.values()) {
-			persist.close();
-		}
-	}
-	
 	private void processChangeSet(SCMRepository repo, ChangeSet cs) {
 		Commit commit = repo.getScm().getCommit(cs.getId());
 		log.info(
 				"Commit #" + commit.getHash() + 
-				" in " + new SimpleDateFormat("dd/MM/yyyy HH:mm:ss").format(commit.getDate().getTime()) +
+				" @ " + repo.getLastDir() +
+				" in " + SIMPLE_DATE_FORMAT.format(commit.getDate().getTime()) +
 				" from " + commit.getAuthor().getName() + 
 				" with " + commit.getModifications().size() + " modifications");
 
@@ -203,18 +164,7 @@ public class RepositoryMining {
 			return;
 		}
 		
-		for(Map.Entry<CommitVisitor, PersistenceMechanism> entry : visitors.entrySet()) {
-			CommitVisitor visitor = entry.getKey();
-			PersistenceMechanism writer = entry.getValue();
-
-			try {
-				log.info("-> Processing " + commit.getHash() + " with " + visitor.name());
-				visitor.process(repo, commit, writer);
-			} catch (Exception e) {
-				log.error("error processing #" + commit.getHash() + " in " + repo.getPath() + 
-						", processor=" + visitor.name() + ", error=" + e.getMessage(), e);
-			}
-		}
+		visitors.processCommit(repo, commit);
 		
 	}
 

--- a/src/main/java/org/repodriller/scm/CommitVisitor.java
+++ b/src/main/java/org/repodriller/scm/CommitVisitor.java
@@ -20,6 +20,8 @@ import org.repodriller.domain.Commit;
 import org.repodriller.persistence.PersistenceMechanism;
 
 public interface CommitVisitor {
+	default void initialize(SCMRepository repo, PersistenceMechanism writer) {}
 	void process(SCMRepository repo, Commit commit, PersistenceMechanism writer);
+	default void finalize(SCMRepository repo, PersistenceMechanism writer) {}
 	String name();
 }


### PR DESCRIPTION
Should methods be renamed to start/end? Would them remain blank-default `CommitVisitor` interface optional or make them mandatory?