### PR TITLE
Update jgit version and utilize try with resources statement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,13 +80,13 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>3.4.1.201406201815-r</version>
+			<version>4.8.0.201706111038-r</version>
 		</dependency>
-
+		
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
The newer version of jgit made all resources implement auto-closable so they can be used in a
try-with resources statement.

this simplifies the resource management and removes boiler plate code.
However it is a rather large version increment so consider this when merging.