### PR TITLE
Rewrite GitRemoteRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ GitRepository.single("/your/project", true);
 
 ## Logging
 
-RepoDriller uses log4j to print useful information about its execution. We recommend you have a log4.xml:
+RepoDriller uses log4j to print useful information about its execution. 
+**Note that this includes Exceptions and their stack traces, which will not appear in standard output.** We recommend you have a log4.xml:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -154,6 +155,8 @@ RepoDriller uses log4j to print useful information about its execution. We recom
 
 </log4j:configuration>
 ```
+
+Put this file in `{project-root}/src/main/resources/` and you should see logs when RepoDriller runs.
 
 ## Selecting the Commit Range
 

--- a/src/main/java/org/repodriller/RepoDrillerException.java
+++ b/src/main/java/org/repodriller/RepoDrillerException.java
@@ -13,4 +13,8 @@ public class RepoDrillerException extends RuntimeException{
 		super(msg);
 	}
 
+	public RepoDrillerException(Exception e) {
+		super(e);
+	}
+
 }

--- a/src/main/java/org/repodriller/domain/ChangeSet.java
+++ b/src/main/java/org/repodriller/domain/ChangeSet.java
@@ -19,21 +19,31 @@ package org.repodriller.domain;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
+/**
+ * A ChangeSet is metadata that uniquely identifies a Commit from an SCM.
+ *
+ * @author Mauricio Aniche
+ */
 public class ChangeSet {
-	
+
 	private final Calendar date;
 	private final String id;
 
 	public ChangeSet(String id, Calendar date) {
 		this.id = id;
 		this.date = date;
-		
 	}
 
+	/**
+	 * @return The time at which this ChangeSet was created by a developer
+	 */
 	public Calendar getTime() {
 		return date;
 	}
 
+	/**
+	 * @return The id of this ChangeSet in its SCM
+	 */
 	public String getId() {
 		return id;
 	}
@@ -49,23 +59,28 @@ public class ChangeSet {
 
 	@Override
 	public boolean equals(Object obj) {
+		/* Boilerplate. */
 		if (this == obj)
 			return true;
 		if (obj == null)
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
+
+		/* Compare two distinct instances. */
 		ChangeSet other = (ChangeSet) obj;
 		if (date == null) {
 			if (other.date != null)
 				return false;
 		} else if (!date.equals(other.date))
 			return false;
+
 		if (id == null) {
 			if (other.id != null)
 				return false;
 		} else if (!id.equals(other.id))
 			return false;
+
 		return true;
 	}
 
@@ -73,6 +88,5 @@ public class ChangeSet {
 	public String toString() {
 		return "[" + id + ", " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date.getTime()) + "]";
 	}
-	
 
 }

--- a/src/main/java/org/repodriller/filter/commit/CommitFilter.java
+++ b/src/main/java/org/repodriller/filter/commit/CommitFilter.java
@@ -2,8 +2,19 @@ package org.repodriller.filter.commit;
 
 import org.repodriller.domain.Commit;
 
+/**
+ * Filter out unwanted Commits.
+ *
+ * @author Mauricio Aniche
+ */
 public interface CommitFilter {
 
+	/**
+	 * Determine whether to accept this commit for further processing.
+	 *
+	 * @param commit	Commit in question
+	 * @return	True if commit should pass the filter, false if it should be filtered out.
+	 */
 	boolean accept(Commit commit);
-	
+
 }

--- a/src/main/java/org/repodriller/filter/range/CommitRange.java
+++ b/src/main/java/org/repodriller/filter/range/CommitRange.java
@@ -5,6 +5,20 @@ import java.util.List;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.scm.SCM;
 
+/**
+ * Return a set of commits from an SCM.
+ *
+ * @author Mauricio Aniche
+ */
+/* TODO It's confusing that this interface is called CommitRange but it returns a list of ChangeSet's, not Commits. */
 public interface CommitRange {
+
+	/**
+	 * Extract the desired commits from this SCM.
+	 *
+	 * @param scm	The SCM to probe.
+	 * @return	List of the ChangeSet's in the range.
+	 */
 	List<ChangeSet> get(SCM scm);
+
 }

--- a/src/main/java/org/repodriller/scm/GitRemoteRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRemoteRepository.java
@@ -2,7 +2,6 @@ package org.repodriller.scm;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,16 +56,13 @@ public class GitRemoteRepository extends GitRepository implements AutoCloseable 
 			this.url = url;
 
 			/* Get a good temp dir name. */
-			String tempDirPath = RDFileUtils.makeTempDir(destination);
-			File dir = new File(tempDirPath);
-			dir.delete();
-
-			/* Concatenate with the repo name. */
+			String tempDirPath = RDFileUtils.getTempPath(destination);
 			String repoName = repoNameFromURL(url);
-			String subdirName = dir.getName() + "-" + repoName;
-			path = Paths.get(destination, subdirName).toAbsolutePath().toString();
+			String cloneDestination = tempDirPath + "-" + repoName;
 
-			log.info("url " + url + " path " + path);
+			path = cloneDestination;
+
+			log.info("url " + url + " destination " + destination + " bare " + bare + " (path " + path + ")");
 
 			/* Fill in GitRepository details. */
 			this.setPath(path);

--- a/src/main/java/org/repodriller/scm/GitRemoteRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRemoteRepository.java
@@ -2,6 +2,7 @@ package org.repodriller.scm;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,142 +10,158 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.repodriller.domain.ChangeSet;
-import org.repodriller.domain.Commit;
+import org.repodriller.RepoDrillerException;
+import org.repodriller.util.RDFileUtils;
 
-/* TODO Name: Sounds like it inherits SCMRepository, but it actually implements SCM. */
-public class GitRemoteRepository implements SCM {
+/**
+ * A GitRepository that knows how to clone a remote repo and clean up after itself.
+ * Instantiating a GitRemoteRepository will clone the specified repo, which
+ *  - is expensive
+ *  - may throw an exception
+ *
+ * @author Jamie Davis
+ */
+public class GitRemoteRepository extends GitRepository implements AutoCloseable {
 
-	private GitRepository tempGitRepository;
-	private String remoteRepositoryUrl;
-	private String tempGitPath;
+	/* Constants. */
+	public static final String URL_SUFFIX = ".git";
+
+	/* Internal. */
+	private boolean hasLocalState = false;
+
+	/* User-defined. */
+	private String url;
+	private String path;
 
 	private static Logger log = Logger.getLogger(GitRemoteRepository.class);
 
+	/**
+	 * @param url	Where do we clone the repo from?
+	 * @throws GitAPIException
+	 * @throws IOException
+	 */
 	public GitRemoteRepository(String url) {
-		this(url, gitSystemTempDir(), false);
+		this(url, null, false);
 	}
 
-	public GitRemoteRepository(String url, String rootTempGitPath, boolean bare) {
+	/**
+	 * @param url	Where do we clone the repo from?
+	 * @param destination	Clone to a tree within rootpath
+	 * @param bare	Bare clone (metadata only) or full?
+	 */
+	public GitRemoteRepository(String url, String destination, boolean bare) {
+		super();
+
 		try {
-			this.remoteRepositoryUrl = url;
-			if(rootTempGitPath == null) {
-				rootTempGitPath = gitSystemTempDir();
-			}
-			this.tempGitPath = gitRemoteRepositoryTempDir(url, rootTempGitPath);
-			this.initTempGitRepository(bare);
-			this.tempGitRepository = new GitRepository(new File(tempGitPath).getCanonicalPath());
-		} catch (Exception e) {
-			log.error("Git remote repository initialization", e);
-			throw new RuntimeException(e);
+			/* Set members. */
+			this.url = url;
+
+			/* Get a good temp dir name. */
+			String tempDirPath = RDFileUtils.makeTempDir(destination);
+			File dir = new File(tempDirPath);
+			dir.delete();
+
+			/* Concatenate with the repo name. */
+			String repoName = repoNameFromURL(url);
+			String subdirName = dir.getName() + "-" + repoName;
+			path = Paths.get(destination, subdirName).toAbsolutePath().toString();
+
+			log.info("url " + url + " path " + path);
+
+			/* Fill in GitRepository details. */
+			this.setPath(path);
+			this.setFirstParentOnly(true); /* TODO. */
+
+			/* Clone the remote repo. */
+			cloneGitRepository(url, path, bare);
+			hasLocalState = true;
+		} catch (IOException|GitAPIException e) {
+			log.error("Unsuccessful git remote repository initialization", e);
+			throw new RepoDrillerException(e);
 		}
 	}
 
-	protected void initTempGitRepository(boolean bare) throws GitAPIException {
-		File directory = new File(this.tempGitPath);
+	/**
+	 * Clone a git repository.
+	 *
+	 * @param url	Where from?
+	 * @param destination	Where to?
+	 * @param bare	Bare (metadata-only) or full?
+	 * @throws GitAPIException
+	 */
+	private void cloneGitRepository(String url, String destination, boolean bare) throws GitAPIException {
+		File directory = new File(destination);
 
-		if(!directory.exists()) {
-			log.info("Cloning Remote Repository " + this.remoteRepositoryUrl + " into " + this.tempGitPath);
-			Git.cloneRepository()
-					.setURI(this.remoteRepositoryUrl)
-					.setBare(bare)
-					.setDirectory(directory)
-					.setCloneAllBranches(true)
-					.setNoCheckout(false)
-					.call();
-		}
+		if (directory.exists())
+			throw new RepoDrillerException("Error, destination " + destination + " already exists");
+
+		log.info("Cloning Remote Repository " + url + " into " + this.path);
+		Git.cloneRepository()
+				.setURI(url)
+				.setBare(bare)
+				.setDirectory(directory)
+				.setCloneAllBranches(true)
+				.setNoCheckout(false)
+				.call();
 	}
 
-	protected static String gitSystemTempDir() {
-		return FileUtils.getTempDirectory().getAbsolutePath();
+	/**
+	 * Extract a git repo name from its URL.
+	 *
+	 * @param url
+	 * @return
+	 */
+	private static String repoNameFromURL(String url) {
+		/* Examples:
+		 *   git@github.com:substack/node-mkdirp.git
+		 *   https://bitbucket.org/fenics-project/notebooks.git
+		 */
+		int lastSlashIx = url.lastIndexOf("/");
+
+		int lastSuffIx = url.lastIndexOf(URL_SUFFIX);
+		if (lastSuffIx < 0)
+			lastSuffIx = url.length();
+
+		if (lastSlashIx < 0 || lastSuffIx <= lastSlashIx)
+			throw new RepoDrillerException("Error, ill-formed url: " + url);
+
+		return url.substring(lastSlashIx + 1, lastSuffIx);
 	}
 
-	protected static String gitRemoteRepositoryTempDir(String remoteRepositoryUrl, String rootTempDir) {
-		int lastIndexOfDotGit = remoteRepositoryUrl.lastIndexOf(".git");
-		if(lastIndexOfDotGit < 0 )
-			lastIndexOfDotGit = remoteRepositoryUrl.length();
-		String directoryName = remoteRepositoryUrl.substring(remoteRepositoryUrl.lastIndexOf("/")+1, lastIndexOfDotGit);
-
-		if(!rootTempDir.endsWith(File.separator))
-			rootTempDir += File.separator;
-
-		return rootTempDir + directoryName;
+	/**
+	 * Clean up this object.
+	 * See {@link GitRemoteRepository#close}.
+	 *
+	 * @throws IOException
+	 */
+	@Deprecated
+	public void deleteTempGitPath() throws IOException {
+		if (hasLocalState)
+			FileUtils.deleteDirectory(new File(this.path));
 	}
+
+	/* Various factory methods. */
 
 	public static SCMRepository singleProject(String url) {
-		return singleProject(url, gitSystemTempDir(), false);
+		return singleProject(url, null, false);
 	}
 
-	protected static SCMRepository singleProject(String url, String rootTempGitPath, boolean bare) {
-		return new GitRemoteRepository(url, rootTempGitPath, bare).info();
+	@SuppressWarnings("resource")
+	public static SCMRepository singleProject(String url, String rootpath, boolean bare) {
+		return new GitRemoteRepository(url, rootpath, bare).info();
 	}
 
-	public static SCMRepository[] allProjectsIn(List<String> urls) {
-		return allProjectsIn(urls, gitSystemTempDir(), false);
+	public static SCMRepository[] allProjectsIn(List<String> urls) throws GitAPIException, IOException {
+		return allProjectsIn(urls, null, false);
 	}
 
-	protected static SCMRepository[] allProjectsIn(List<String> urls, String rootTempGitPath, boolean bare) {
+	protected static SCMRepository[] allProjectsIn(List<String> urls, String rootpath, boolean bare) {
 		List<SCMRepository> repos = new ArrayList<SCMRepository>();
 		for (String url : urls) {
-			repos.add(singleProject(url, rootTempGitPath, bare));
+			repos.add(singleProject(url, rootpath, bare));
 		}
 
 		return repos.toArray(new SCMRepository[repos.size()]);
-	}
-
-	public void deleteTempGitPath() throws IOException {
-		FileUtils.deleteDirectory(new File(this.tempGitPath));
-	}
-
-	@Override
-	public SCMRepository info() {
-		return tempGitRepository.info();
-	}
-
-	@Override
-	public ChangeSet getHead() {
-		return tempGitRepository.getHead();
-	}
-
-	@Override
-	public List<ChangeSet> getChangeSets() {
-		return tempGitRepository.getChangeSets();
-	}
-
-	@Override
-	public Commit getCommit(String id) {
-		return tempGitRepository.getCommit(id);
-	}
-
-	@Override
-	public void checkout(String hash) {
-		tempGitRepository.checkout(hash);
-	}
-
-	@Override
-	public List<RepositoryFile> files() {
-		return tempGitRepository.files();
-	}
-
-	@Override
-	public void reset() {
-		tempGitRepository.reset();
-	}
-
-	@Override
-	public long totalCommits() {
-		return tempGitRepository.totalCommits();
-	}
-
-	@Override
-	@Deprecated
-	public String blame(String file, String currentCommit, Integer line) {
-		return tempGitRepository.blame(file, currentCommit, line);
-	}
-
-	@Override
-	public List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit) {
-		return tempGitRepository.blame(file, commitToBeBlamed, priorCommit);
 	}
 
 	public static SingleGitRemoteRepositoryBuilder hostedOn(String gitUrl) {
@@ -155,9 +172,11 @@ public class GitRemoteRepository implements SCM {
 		return new MultipleGitRemoteRepositoryBuilder(gitUrls);
 	}
 
-	@Override
-	public String getCommitFromTag(String tag) {
-		return tempGitRepository.getCommitFromTag(tag);
-	}
+	/* Interface: AutoCloseable. */
 
+	@Override
+	public void close() throws IOException {
+		if (hasLocalState)
+			FileUtils.deleteDirectory(new File(path));
+	}
 }

--- a/src/main/java/org/repodriller/scm/GitRemoteRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRemoteRepository.java
@@ -12,18 +12,19 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
 
+/* TODO Name: Sounds like it inherits SCMRepository, but it actually implements SCM. */
 public class GitRemoteRepository implements SCM {
-	
+
 	private GitRepository tempGitRepository;
 	private String remoteRepositoryUrl;
 	private String tempGitPath;
 
 	private static Logger log = Logger.getLogger(GitRemoteRepository.class);
-	
+
 	public GitRemoteRepository(String url) {
 		this(url, gitSystemTempDir(), false);
 	}
-	
+
 	public GitRemoteRepository(String url, String rootTempGitPath, boolean bare) {
 		try {
 			this.remoteRepositoryUrl = url;
@@ -38,10 +39,10 @@ public class GitRemoteRepository implements SCM {
 			throw new RuntimeException(e);
 		}
 	}
-	
+
 	protected void initTempGitRepository(boolean bare) throws GitAPIException {
 		File directory = new File(this.tempGitPath);
-		
+
 		if(!directory.exists()) {
 			log.info("Cloning Remote Repository " + this.remoteRepositoryUrl + " into " + this.tempGitPath);
 			Git.cloneRepository()
@@ -57,7 +58,7 @@ public class GitRemoteRepository implements SCM {
 	protected static String gitSystemTempDir() {
 		return FileUtils.getTempDirectory().getAbsolutePath();
 	}
-	
+
 	protected static String gitRemoteRepositoryTempDir(String remoteRepositoryUrl, String rootTempDir) {
 		int lastIndexOfDotGit = remoteRepositoryUrl.lastIndexOf(".git");
 		if(lastIndexOfDotGit < 0 )
@@ -66,31 +67,31 @@ public class GitRemoteRepository implements SCM {
 
 		if(!rootTempDir.endsWith(File.separator))
 			rootTempDir += File.separator;
-		
+
 		return rootTempDir + directoryName;
 	}
-	
+
 	public static SCMRepository singleProject(String url) {
 		return singleProject(url, gitSystemTempDir(), false);
 	}
-	
+
 	protected static SCMRepository singleProject(String url, String rootTempGitPath, boolean bare) {
 		return new GitRemoteRepository(url, rootTempGitPath, bare).info();
 	}
-	
+
 	public static SCMRepository[] allProjectsIn(List<String> urls) {
 		return allProjectsIn(urls, gitSystemTempDir(), false);
 	}
-	
+
 	protected static SCMRepository[] allProjectsIn(List<String> urls, String rootTempGitPath, boolean bare) {
 		List<SCMRepository> repos = new ArrayList<SCMRepository>();
 		for (String url : urls) {
 			repos.add(singleProject(url, rootTempGitPath, bare));
 		}
-		
+
 		return repos.toArray(new SCMRepository[repos.size()]);
 	}
-	
+
 	public void deleteTempGitPath() throws IOException {
 		FileUtils.deleteDirectory(new File(this.tempGitPath));
 	}
@@ -145,7 +146,7 @@ public class GitRemoteRepository implements SCM {
 	public List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit) {
 		return tempGitRepository.blame(file, commitToBeBlamed, priorCommit);
 	}
-	
+
 	public static SingleGitRemoteRepositoryBuilder hostedOn(String gitUrl) {
 		return new SingleGitRemoteRepositoryBuilder(gitUrl);
 	}
@@ -158,5 +159,5 @@ public class GitRemoteRepository implements SCM {
 	public String getCommitFromTag(String tag) {
 		return tempGitRepository.getCommitFromTag(tag);
 	}
-	
+
 }

--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -72,9 +72,10 @@ public class GitRepository implements SCM {
 	private boolean firstParentOnly = false;
 
 	/**
-	 * Make sub-classing easier. Make sure you initialize appropriately with the Setters.
+	 * Intended for sub-classes.
+	 * Make sure you initialize appropriately with the Setters.
 	 */
-	public GitRepository() {
+	protected GitRepository() {
 		this(null);
 	}
 
@@ -487,16 +488,8 @@ public class GitRepository implements SCM {
 		return ref.getObjectId();
 	}
 
-	public String getPath() {
-		return path;
-	}
-
 	public void setPath(String path) {
 		this.path = path;
-	}
-
-	public boolean isFirstParentOnly() {
-		return firstParentOnly;
 	}
 
 	public void setFirstParentOnly(boolean firstParentOnly) {

--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -51,31 +51,43 @@ import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
 import org.repodriller.domain.Developer;
 import org.repodriller.domain.ModificationType;
-import org.repodriller.util.FileUtils;
+import org.repodriller.util.RDFileUtils;
 
 public class GitRepository implements SCM {
 
+	/* Constants. */
 	private static final int MAX_SIZE_OF_A_DIFF = 100000;
 	private static final int DEFAULT_MAX_NUMBER_OF_FILES_IN_A_COMMIT = 5000;
 	private static final String BRANCH_MM = "mm";
 
-	private String path;
-	private String mainBranchName;
-	private int maxNumberFilesInACommit;
-	private int maxSizeOfDiff;
+	/* Auto-determined. */
+	private String mainBranchName = null;
+	private int maxNumberFilesInACommit = -1;
+	private int maxSizeOfDiff = -1;
 
 	private static Logger log = Logger.getLogger(GitRepository.class);
-	private boolean firstParentOnly;
 
-	public GitRepository(String path, boolean firstParentOnly) {
-		this.path = path;
-		this.firstParentOnly = firstParentOnly;
-		this.maxNumberFilesInACommit = checkMaxNumberOfFiles();
-		this.maxSizeOfDiff = checkMaxSizeOfDiff();
+	/* User-specified. */
+	private String path = null;
+	private boolean firstParentOnly = false;
+
+	/**
+	 * Make sub-classing easier. Make sure you initialize appropriately with the Setters.
+	 */
+	public GitRepository() {
+		this(null);
 	}
 
 	public GitRepository(String path) {
 		this(path, false);
+	}
+
+	public GitRepository(String path, boolean firstParentOnly) {
+		setPath(path);
+		setFirstParentOnly(firstParentOnly);
+
+		this.maxNumberFilesInACommit = checkMaxNumberOfFiles();
+		this.maxSizeOfDiff = checkMaxSizeOfDiff();
 	}
 
 	private int checkMaxNumberOfFiles() {
@@ -105,11 +117,11 @@ public class GitRepository implements SCM {
 	public static SCMRepository[] allProjectsIn(String path) {
 		return allProjectsIn(path, false);
 	}
-	
+
 	public static SCMRepository[] allProjectsIn(String path, boolean singleParentOnly) {
 		List<SCMRepository> repos = new ArrayList<>();
 
-		for (String dir : FileUtils.getAllDirsIn(path)) {
+		for (String dir : RDFileUtils.getAllDirsIn(path)) {
 			repos.add(singleProject(dir, singleParentOnly));
 		}
 
@@ -119,7 +131,7 @@ public class GitRepository implements SCM {
 	public SCMRepository info() {
 		try (Git git = openRepository(); RevWalk rw = new RevWalk(git.getRepository())) {
             AnyObjectId headId = git.getRepository().resolve(Constants.HEAD);
-            
+
 			RevCommit root = rw.parseCommit(headId);
 			rw.sort(RevSort.REVERSE);
 			rw.markStart(root);
@@ -174,7 +186,7 @@ public class GitRepository implements SCM {
 	private List<ChangeSet> firstParentsOnly(Git git) {
 		try {
 			List<ChangeSet> allCs = new ArrayList<>();
-			
+
 			RevWalk revWalk = new RevWalk(git.getRepository());
 			revWalk.setRevFilter(new FirstParentFilter());
 			revWalk.sort(RevSort.TOPO);
@@ -184,9 +196,9 @@ public class GitRepository implements SCM {
 			for(RevCommit revCommit : revWalk) {
 				allCs.add(extractChangeSet(revCommit));
 			}
-			
+
 			return allCs;
-			
+
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -212,7 +224,7 @@ public class GitRepository implements SCM {
 		GregorianCalendar date = new GregorianCalendar();
 		date.setTimeZone(revCommit.getAuthorIdent().getTimeZone());
 		date.setTime(revCommit.getAuthorIdent().getWhen());
-		
+
 		return date;
 	}
 
@@ -231,7 +243,7 @@ public class GitRepository implements SCM {
 
 				TimeZone authorTimeZone = jgitCommit.getAuthorIdent().getTimeZone();
 				TimeZone committerTimeZone = jgitCommit.getCommitterIdent().getTimeZone();
-				
+
 				String msg = jgitCommit.getFullMessage().trim();
 				String hash = jgitCommit.getName().toString();
 				String parent = (jgitCommit.getParentCount() > 0) ? jgitCommit.getParent(0).getName().toString() : "";
@@ -243,7 +255,7 @@ public class GitRepository implements SCM {
 				GregorianCalendar committerDate = new GregorianCalendar();
 				committerDate.setTime(jgitCommit.getCommitterIdent().getWhen());
 				committerDate.setTimeZone(jgitCommit.getCommitterIdent().getTimeZone());
-				
+
 				boolean merge = false;
 				if(jgitCommit.getParentCount() > 1) merge = true;
 				Set<String> branches = getBranches(git, hash);
@@ -274,7 +286,7 @@ public class GitRepository implements SCM {
 						log.error("diff for " + newPath + " too big");
 						diffText = "-- TOO BIG --";
 					}
-					
+
 					theCommit.addModification(oldPath, newPath, change, diffText, sc);
 
 				}
@@ -302,7 +314,7 @@ public class GitRepository implements SCM {
 
 		AnyObjectId currentCommit = repo.resolve(commit.getName());
 		AnyObjectId parentCommit = commit.getParentCount() > 0 ? repo.resolve(commit.getParent(0).getName()) : null;
-    
+
 		try (DiffFormatter df = new DiffFormatter(DisabledOutputStream.INSTANCE)) {
 
             df.setBinaryFileThreshold(2 * 1024); // 2 mb max a file
@@ -394,7 +406,7 @@ public class GitRepository implements SCM {
 	}
 
 	private List<File> getAllFilesInPath() {
-		return FileUtils.getAllFilesInPath(path);
+		return RDFileUtils.getAllFilesInPath(path);
 	}
 
 	@Override
@@ -407,11 +419,11 @@ public class GitRepository implements SCM {
 	public String blame(String file, String commitToBeBlamed, Integer line) {
 		return blame(file,commitToBeBlamed).get(line).getCommit();
 	}
-	
+
 	public List<BlamedLine> blame(String file, String commitToBeBlamed) {
 		return blame(file, commitToBeBlamed, true);
 	}
-	
+
 	public List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit) {
         try (Git git = openRepository()) {
 			ObjectId gitCommitToBeBlamed;
@@ -419,7 +431,7 @@ public class GitRepository implements SCM {
 				Iterable<RevCommit> commits = git.log().add(git.getRepository().resolve(commitToBeBlamed)).call();
 				gitCommitToBeBlamed = commits.iterator().next().getParent(0).getId();
 			} else {
-				gitCommitToBeBlamed = git.getRepository().resolve(commitToBeBlamed); 
+				gitCommitToBeBlamed = git.getRepository().resolve(commitToBeBlamed);
 			}
 
 			BlameResult blameResult = git.blame().setFilePath(file).setStartCommit(gitCommitToBeBlamed).setFollowFileRenames(true).call();
@@ -427,13 +439,13 @@ public class GitRepository implements SCM {
 				int rows = blameResult.getResultContents().size();
 				List<BlamedLine> result = new ArrayList<>();
 				for(int i = 0; i < rows; i++) {
-					result.add(new BlamedLine(i, 
-							blameResult.getResultContents().getString(i), 
-							blameResult.getSourceAuthor(i).getName(), 
-							blameResult.getSourceCommitter(i).getName(), 
+					result.add(new BlamedLine(i,
+							blameResult.getResultContents().getString(i),
+							blameResult.getSourceAuthor(i).getName(),
+							blameResult.getSourceCommitter(i).getName(),
 							blameResult.getSourceCommit(i).getId().getName()));
 				}
-				
+
 				return result;
 			} else {
 				throw new RuntimeException("BlameResult not found.");
@@ -443,7 +455,7 @@ public class GitRepository implements SCM {
 			throw new RuntimeException(e);
 		}
 	}
-	
+
 	public Integer getMaxNumberFilesInACommit() {
 		return maxNumberFilesInACommit;
 	}
@@ -455,23 +467,39 @@ public class GitRepository implements SCM {
 			Repository repo = git.getRepository();
 
 			Iterable<RevCommit> commits = git.log().add(getActualRefObjectId(repo.findRef(tag), repo)).call();
-			
+
 			for(RevCommit commit : commits) {
 				return commit.getName().toString();
 			}
-			
+
 			throw new RuntimeException("Failed for tag " + tag); // we never arrive here, hopefully
 
 		} catch (Exception e) {
 			throw new RuntimeException("Failed for tag " + tag, e);
 		}
 	}
-	
+
 	private ObjectId getActualRefObjectId(Ref ref, Repository repo) {
 		final Ref repoPeeled = repo.peel(ref);
 		if(repoPeeled.getPeeledObjectId() != null) {
 			return repoPeeled.getPeeledObjectId();
 		}
 		return ref.getObjectId();
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public boolean isFirstParentOnly() {
+		return firstParentOnly;
+	}
+
+	public void setFirstParentOnly(boolean firstParentOnly) {
+		this.firstParentOnly = firstParentOnly;
 	}
 }

--- a/src/main/java/org/repodriller/scm/RepositoryFile.java
+++ b/src/main/java/org/repodriller/scm/RepositoryFile.java
@@ -2,7 +2,7 @@ package org.repodriller.scm;
 
 import java.io.File;
 
-import org.repodriller.util.FileUtils;
+import org.repodriller.util.RDFileUtils;
 
 public class RepositoryFile {
 
@@ -33,7 +33,7 @@ public class RepositoryFile {
 	}
 	
 	public String getSourceCode() {
-		return FileUtils.readFile(getFile());
+		return RDFileUtils.readFile(getFile());
 	}
 	
 	@Override

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -21,19 +21,76 @@ import java.util.List;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
 
+/**
+ * This interface defines interactions with a source code repository that uses a Source Code Management system (i.e. version control system).
+ * In essence, any SCM consists of a set of commits in a possibly-linear directed acyclic graph (DAG).
+ *
+ * An SCM:
+ *  - Maintains a set of Commits (full details) that are uniquely identified with ChangeSets (metadata)
+ *  - Has a "most recent commit" called its head
+ *  - Can roll back the state of the repository to a particular Commit
+ *  - Can return to the head
+ *
+ * @author Mauricio Aniche
+ */
 public interface SCM {
 
-	List<ChangeSet> getChangeSets();
-	Commit getCommit(String id);
-	String getCommitFromTag(String tag);
-	ChangeSet getHead();
-	List<RepositoryFile> files();
+	/* Methods for general information about the SCM. */
+
+	/**
+	 * @return Total commits in this SCM.
+	 */
 	long totalCommits();
-	void reset();
-	void checkout(String id);
+
+	/**
+	 * @return ChangeSet representing the "head" (most recent) commit.
+	 */
+	ChangeSet getHead();
+
+	/**
+	 * @return All ChangeSets in this SCM.
+	 */
+	List<ChangeSet> getChangeSets();
+
+	/**
+	 * @return Metadata about this SCM.
+	 */
+	SCMRepository info();
+
+	/* Methods for retrieving Commits. */
+
+	/**
+	 * Retrieve the Commit with this id.
+	 *
+	 * @param id	The commit to retrieve
+	 * @return	The Commit with this id, or null.
+	 */
+	Commit getCommit(String id);
+	/* TODO A method named getCommitXYZ should return a Commit. */
+	String getCommitFromTag(String tag);
+
 	@Deprecated
 	String blame(String file, String currentCommit, Integer line);
 	List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit);
-	SCMRepository info();
 
+	/* Methods for interacting with current repo state. */
+
+	/**
+	 * Return the repo to the state immediately following the application of the Commit identified by this id.
+	 * @param id	The commit to checkout.
+	 * Implementors: May not be thread safe, consider synchronized.
+	 */
+	void checkout(String id);
+
+	/**
+	 * Return the repo to the state of the head commit.
+	 * Implementors: May not be thread safe, consider synchronized.
+	 */
+	void reset();
+
+	/**
+	 * @return All files currently in the repo.
+	 * Implementors: May not be thread safe, consider synchronized.
+	 */
+	List<RepositoryFile> files();
 }

--- a/src/main/java/org/repodriller/scm/SCMRepository.java
+++ b/src/main/java/org/repodriller/scm/SCMRepository.java
@@ -16,13 +16,22 @@
 
 package org.repodriller.scm;
 
+/**
+ * An SCMRepository represents a Source Code Management Repository, i.e. an instance of source code maintained with a version control system.
+ * An SCMRepository includes:
+ *  - some metadata about the repo
+ *  - an SCM instance with the contents of the repo
+ *
+ * @author Mauricio Aniche
+ */
+/* TODO Naming is confusing. */
 public class SCMRepository {
 
-	private String path;
-	private String headCommit;
-	private String firstCommit;
+	private String path; /* Path in local FS. */
+	private String headCommit; /* Most recent commit. */
+	private String firstCommit; /* First commit. */
 	private SCM scm;
-	private String origin;
+	private String origin; /* e.g. GitHub URL */
 
 	public SCMRepository(SCM scm, String origin, String path, String headCommit, String firstCommit) {
 		this.scm = scm;
@@ -31,7 +40,7 @@ public class SCMRepository {
 		this.headCommit = headCommit;
 		this.firstCommit = firstCommit;
 	}
-	
+
 	public String getPath() {
 		return path;
 	}
@@ -49,9 +58,9 @@ public class SCMRepository {
 	}
 
 	public String getOrigin() {
-		return origin==null?path:origin;
+		return origin == null ? path : origin;
 	}
-	
+
 	public String getLastDir() {
 		String[] dirs = path.replace("\\", "/").split("/");
 		return dirs[dirs.length-1];
@@ -62,7 +71,5 @@ public class SCMRepository {
 		return "SCMRepository [path=" + path + ", headCommit=" + headCommit + ", lastCommit=" + firstCommit + ", scm="
 				+ scm + ", origin=" + origin + "]";
 	}
-	
-	
-	
+
 }

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -19,7 +19,7 @@ import org.repodriller.domain.Commit;
 import org.repodriller.domain.Developer;
 import org.repodriller.domain.Modification;
 import org.repodriller.domain.ModificationType;
-import org.repodriller.util.FileUtils;
+import org.repodriller.util.RDFileUtils;
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNDirEntry;
 import org.tmatesoft.svn.core.SVNException;
@@ -101,7 +101,7 @@ public class SubversionRepository implements SCM {
 	public static SCMRepository[] allProjectsIn(String path, Integer maxNumberOfFilesInACommit) {
 		List<SCMRepository> repos = new ArrayList<SCMRepository>();
 
-		for (String dir : FileUtils.getAllDirsIn(path)) {
+		for (String dir : RDFileUtils.getAllDirsIn(path)) {
 			repos.add(singleProject(dir, maxNumberOfFilesInACommit));
 		}
 
@@ -319,7 +319,7 @@ public class SubversionRepository implements SCM {
 	}
 
 	private List<File> getAllFilesInPath() {
-		return FileUtils.getAllFilesInPath(workingCopyPath);
+		return RDFileUtils.getAllFilesInPath(workingCopyPath);
 	}
 
 	private boolean isNotAnImportantFile(File f) {

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -40,6 +40,7 @@ import org.tmatesoft.svn.core.wc.SVNUpdateClient;
  * @author Juliano Silva
  *
  */
+/* TODO Name: Sounds like it inherits SCMRepository, but it actually implements SCM. */
 public class SubversionRepository implements SCM {
 
 	private static final int MAX_SIZE_OF_A_DIFF = 100000;
@@ -443,7 +444,7 @@ public class SubversionRepository implements SCM {
 		// pull request me!
 		throw new RuntimeException("implement me!");
 	}
-	
+
 	public Integer getMaxNumberFilesInACommit() {
 		return maxNumberFilesInACommit;
 	}
@@ -453,5 +454,5 @@ public class SubversionRepository implements SCM {
 		// pull request me!
 		throw new RuntimeException("implement me!");
 	}
-	
+
 }

--- a/src/main/java/org/repodriller/util/FileUtils.java
+++ b/src/main/java/org/repodriller/util/FileUtils.java
@@ -7,8 +7,19 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 
+/**
+ * Various utilities for working with files.
+ *
+ * @author Mauricio Aniche
+ */
 public class FileUtils {
 
+	/**
+	 * Get the absolute path to all subdirs of {@code path}.
+	 *
+	 * @param path	Root of directory tree
+	 * @return	All children of this root that are subdirs
+	 */
 	public static List<String> getAllDirsIn(String path) {
 		File dir = new File(path);
 		String[] files = dir.list();
@@ -20,13 +31,30 @@ public class FileUtils {
 				projects.add(possibleDir.getAbsolutePath());
 			}
 		}
-
 		return projects;
 	}
+
+	/**
+	 * Recursively find all the files in this tree, except those in .git and .svn subdirs
+	 *
+	 * @param pathToLook	Tree root
+	 * @return	Every file in this tree for which File.isFile(), except those in
+	 */
 	public static List<File> getAllFilesInPath(String pathToLook) {
 		return getAllFilesInPath(pathToLook, new ArrayList<>());
 	}
 
+	/**
+	 * Helper for getAllFilesInPath.
+	 *
+	 * @param pathToLook	Tree root
+	 * @param files	Ongoing collection of files (not dirs)
+	 * @return	{@code files} plus all files in the tree rooted at pathToLook
+	 *          Files that are in .svn or .git dirs are ignored.
+	 */
+	/* TODO It's strange that a FileUtils class knows abuot .svn and .git.
+	 * 		If you want to blacklist subtrees, these should be arguments, not hardcoded in this class.
+	 */
 	private static List<File> getAllFilesInPath(String pathToLook, List<File> files) {
 		for (File f : new File(pathToLook).listFiles()) {
 			if (f.isFile())
@@ -36,8 +64,13 @@ public class FileUtils {
 		}
 		return files;
 	}
-	
 
+	/**
+	 * Return the raw contents of this file
+	 *
+	 * @param f	File to read
+	 * @return	Contents of file as string
+	 */
 	public static String readFile(File f) {
 		try {
 			FileInputStream input = new FileInputStream(f);
@@ -45,11 +78,16 @@ public class FileUtils {
 			input.close();
 			return text;
 		} catch (Exception e) {
-			throw new RuntimeException("error reading file " + f.getAbsolutePath(), e);
+			throw new RuntimeException("Error reading file " + f.getAbsolutePath(), e);
 		}
 	}
-	
 
+	/**
+	 * True if f is a directory and doesn't look like svn or git metadata
+	 *
+	 * @param f
+	 * @return True if it looks like a "project subdirectory"
+	 */
 	private static boolean isAProjectSubdirectory(File f) {
 		return f.isDirectory() && !f.getName().equals(".svn") && !f.getName().equals(".git");
 	}

--- a/src/main/java/org/repodriller/util/RDFileUtils.java
+++ b/src/main/java/org/repodriller/util/RDFileUtils.java
@@ -2,9 +2,11 @@ package org.repodriller.util;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 /**
@@ -12,7 +14,7 @@ import org.apache.commons.io.IOUtils;
  *
  * @author Mauricio Aniche
  */
-public class FileUtils {
+public class RDFileUtils {
 
 	/**
 	 * Get the absolute path to all subdirs of {@code path}.
@@ -52,9 +54,6 @@ public class FileUtils {
 	 * @return	{@code files} plus all files in the tree rooted at pathToLook
 	 *          Files that are in .svn or .git dirs are ignored.
 	 */
-	/* TODO It's strange that a FileUtils class knows abuot .svn and .git.
-	 * 		If you want to blacklist subtrees, these should be arguments, not hardcoded in this class.
-	 */
 	private static List<File> getAllFilesInPath(String pathToLook, List<File> files) {
 		for (File f : new File(pathToLook).listFiles()) {
 			if (f.isFile())
@@ -88,7 +87,34 @@ public class FileUtils {
 	 * @param f
 	 * @return True if it looks like a "project subdirectory"
 	 */
+	/* TODO It's strange that a FileUtils class knows about .svn and .git.
+	 * 		If you want to blacklist subtrees, these should be arguments, not hardcoded in this class.
+	 */
 	private static boolean isAProjectSubdirectory(File f) {
 		return f.isDirectory() && !f.getName().equals(".svn") && !f.getName().equals(".git");
+	}
+
+	/**
+	 * Create a unique temporary directory.
+	 *
+	 * @param directory	Where to root the temp dir, defaults to the system temp dir
+	 * @return	Absolute path to a newly created temp directory
+	 * @throws IOException
+	 */
+	public static String makeTempDir(String directory) throws IOException {
+		try {
+			if (directory == null) {
+				directory = FileUtils.getTempDirectoryPath();
+			}
+
+			File tmpFile = File.createTempFile("RD-", "", new File(directory));
+			tmpFile.delete();
+			if (tmpFile.mkdir())
+				return tmpFile.getAbsolutePath();
+			else
+				throw new IOException("Error, couldn't create temp dir in " + directory);
+		} catch (IOException e) {
+			throw new IOException("Error, couldn't create temp dir in " + directory + ": " + e);
+		}
 	}
 }

--- a/src/main/java/org/repodriller/util/RDFileUtils.java
+++ b/src/main/java/org/repodriller/util/RDFileUtils.java
@@ -95,24 +95,24 @@ public class RDFileUtils {
 	}
 
 	/**
-	 * Create a unique temporary directory.
+	 * Get a unique path that does not yet exist
 	 *
-	 * @param directory	Where to root the temp dir, defaults to the system temp dir
-	 * @return	Absolute path to a newly created temp directory
+	 * @param directory	Where to begin the path, defaults to the system temp dir
+	 * @return	Absolute path to an available file
 	 * @throws IOException
 	 */
-	public static String makeTempDir(String directory) throws IOException {
+	public static String getTempPath(String directory) throws IOException {
 		try {
-			if (directory == null) {
+			if (directory == null)
 				directory = FileUtils.getTempDirectoryPath();
-			}
 
-			File tmpFile = File.createTempFile("RD-", "", new File(directory));
+			File dir = new File(directory);
+			dir.mkdirs();
+
+			File tmpFile = File.createTempFile("RD-", "", dir);
+			String absPath = tmpFile.getAbsolutePath();
 			tmpFile.delete();
-			if (tmpFile.mkdir())
-				return tmpFile.getAbsolutePath();
-			else
-				throw new IOException("Error, couldn't create temp dir in " + directory);
+			return absPath;
 		} catch (IOException e) {
 			throw new IOException("Error, couldn't create temp dir in " + directory + ": " + e);
 		}

--- a/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
@@ -80,8 +80,7 @@ public class GitRemoteRepositoryTest {
 	 * Doesn't work in every machine/filesystem.
 	 * Mock to avoid this issue and make test independent of internet connection?
 	 */
-	/* TODO This works on my Linux box. Can someone test on Windows? */
-//	@AfterClass
+	@AfterClass
 	public static void deleteTempResource() throws IOException {
 		Collection<GitRemoteRepository> repos = new ArrayList<GitRemoteRepository>();
 		repos.add(git1);

--- a/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
@@ -18,6 +18,10 @@ package org.repodriller.scm.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -39,11 +43,11 @@ public class GitRemoteRepositoryTest {
 	@BeforeClass()
 	public static void readPath() throws InvalidRemoteException, TransportException, GitAPIException, IOException {
 		url = "https://github.com/mauricioaniche/repodriller";
-		
+
 		String toDel = FileUtils.getTempDirectory().getAbsolutePath() + File.separator + "repodriller";
 		FileUtils.deleteDirectory(new File(toDel));
 		git1 = new GitRemoteRepository(url);
-		
+
 		FileUtils.deleteDirectory(new File(REMOTE_GIT_TEMP_DIR + File.separator + "repodriller"));
 		git2 = GitRemoteRepository.hostedOn(url).inTempDir(REMOTE_GIT_TEMP_DIR).asBareRepos().build();
 	}
@@ -53,37 +57,42 @@ public class GitRemoteRepositoryTest {
 		SCMRepository repo = git1.info();
 		Assert.assertEquals("c79c45449201edb2895f48144a3b29cdce7c6f47", repo.getFirstCommit());
 	}
-	
+
 	@Test
 	public void shouldGetSameOriginURL() {
 		SCMRepository repo = git1.info();
 		String origin = repo.getOrigin();
 		Assert.assertEquals(url, origin);
 	}
-	
+
 	@Test
 	public void shouldInitWithGivenTempDir() {
-		String expectedRepoTempDirectory = new File(REMOTE_GIT_TEMP_DIR + File.separator + "repodriller").getAbsolutePath();
-		Assert.assertEquals(expectedRepoTempDirectory, git2.info().getPath());
-		
-		File bareRepositoryRefDir = new File(expectedRepoTempDirectory + File.separator + "refs");
-		Assert.assertTrue("A bare repository should have refs directory.", bareRepositoryRefDir.exists());
+		Path expectedStart = Paths.get(REMOTE_GIT_TEMP_DIR).toAbsolutePath();
+		Assert.assertTrue("Directory " + REMOTE_GIT_TEMP_DIR + " not honored. Path is " + git2.info().getPath(),
+				Paths.get(git2.info().getPath()).startsWith(expectedStart));
+
+		File bareRepositoryRefDir = new File(git2.info().getPath() + File.separator + "refs");
+		Assert.assertTrue("A bare repository should have a refs directory",
+				bareRepositoryRefDir.exists());
 	}
-	
+
 	/**
 	 * Doesn't work in every machine/filesystem.
 	 * Mock to avoid this issue and make test independent of internet connection?
 	 */
+	/* TODO This works on my Linux box. Can someone test on Windows? */
 //	@AfterClass
 	public static void deleteTempResource() throws IOException {
-		String repoTempPath = git1.info().getPath();
-		git1.deleteTempGitPath();
-		File tempPathDir = new File(repoTempPath);
-		Assert.assertFalse("Temporary directory should be deleted.", tempPathDir.exists());
-		
-		git2.deleteTempGitPath();
-		File givenTempDir = new File(REMOTE_GIT_TEMP_DIR);
-		Assert.assertFalse("Given temporary directory should be deleted.", givenTempDir.exists());
+		Collection<GitRemoteRepository> repos = new ArrayList<GitRemoteRepository>();
+		repos.add(git1);
+		repos.add(git2);
+
+		for (GitRemoteRepository repo : repos) {
+			String repoPath = repo.info().getPath();
+			repo.close();
+			File dir = new File(repoPath);
+			Assert.assertFalse("Remote repo's directory should be deleted: " + repoPath, dir.exists());
+
+		}
 	}
-	
 }

--- a/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
@@ -80,7 +80,8 @@ public class GitRemoteRepositoryTest {
 	 * Doesn't work in every machine/filesystem.
 	 * Mock to avoid this issue and make test independent of internet connection?
 	 */
-	@AfterClass
+	 /* TODO Should enable this to clean up after running tests. Or otherwise avoid dir pollution, e.g. using the system temp dir as the temp directory rather than putting it in the repodriller tree. */
+//	@AfterClass
 	public static void deleteTempResource() throws IOException {
 		Collection<GitRemoteRepository> repos = new ArrayList<GitRemoteRepository>();
 		repos.add(git1);


### PR DESCRIPTION
Addresses #84.

Problem:
GitRemoteRepository essentially implemented SCM by passing off all the SCM stuff to a GitRepository member.
This resulted in redundant code.

Solution:
GitRemoteRepository now extends GitRepository and implements AutoCloseable.
During construction it clones the repo.
During close it deletes its cloned copy of the repo.
Everything else can be inherited from GitRepository without a problem.

Bonus:
Also includes rename of FileUtils, #83.