### PR TITLE
Rewrite GitRemoteRepository

### DIFF
--- a/src/main/java/org/repodriller/RepoDrillerException.java
+++ b/src/main/java/org/repodriller/RepoDrillerException.java
@@ -13,4 +13,8 @@ public class RepoDrillerException extends RuntimeException{
 		super(msg);
 	}
 
+	public RepoDrillerException(Exception e) {
+		super(e);
+	}
+
 }

--- a/src/main/java/org/repodriller/scm/GitRemoteRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRemoteRepository.java
@@ -9,142 +9,154 @@ import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.repodriller.domain.ChangeSet;
-import org.repodriller.domain.Commit;
+import org.repodriller.RepoDrillerException;
+import org.repodriller.util.RDFileUtils;
 
-/* TODO Name: Sounds like it inherits SCMRepository, but it actually implements SCM. */
-public class GitRemoteRepository implements SCM {
+/**
+ * A GitRepository that knows how to clone a remote repo and clean up after itself.
+ * Instantiating a GitRemoteRepository will clone the specified repo, which
+ *  - is expensive
+ *  - may throw an exception
+ *
+ * @author Jamie Davis
+ */
+public class GitRemoteRepository extends GitRepository implements AutoCloseable {
 
-	private GitRepository tempGitRepository;
-	private String remoteRepositoryUrl;
-	private String tempGitPath;
+	/* Constants. */
+	public static final String URL_SUFFIX = ".git";
+
+	/* Internal. */
+	private boolean hasLocalState = false;
+
+	/* User-defined. */
+	private String url;
+	private String path;
 
 	private static Logger log = Logger.getLogger(GitRemoteRepository.class);
 
+	/**
+	 * @param url	Where do we clone the repo from?
+	 * @throws GitAPIException
+	 * @throws IOException
+	 */
 	public GitRemoteRepository(String url) {
-		this(url, gitSystemTempDir(), false);
+		this(url, null, false);
 	}
 
-	public GitRemoteRepository(String url, String rootTempGitPath, boolean bare) {
+	/**
+	 * @param url	Where do we clone the repo from?
+	 * @param destination	Clone to a tree within rootpath
+	 * @param bare	Bare clone (metadata only) or full?
+	 */
+	public GitRemoteRepository(String url, String destination, boolean bare) {
+		super();
+
 		try {
-			this.remoteRepositoryUrl = url;
-			if(rootTempGitPath == null) {
-				rootTempGitPath = gitSystemTempDir();
-			}
-			this.tempGitPath = gitRemoteRepositoryTempDir(url, rootTempGitPath);
-			this.initTempGitRepository(bare);
-			this.tempGitRepository = new GitRepository(new File(tempGitPath).getCanonicalPath());
-		} catch (Exception e) {
-			log.error("Git remote repository initialization", e);
-			throw new RuntimeException(e);
+			/* Set members. */
+			this.url = url;
+
+			/* Get a good temp dir name. */
+			String tempDirPath = RDFileUtils.getTempPath(destination);
+			String repoName = repoNameFromURL(url);
+			String cloneDestination = tempDirPath + "-" + repoName;
+
+			path = cloneDestination;
+
+			log.info("url " + url + " destination " + destination + " bare " + bare + " (path " + path + ")");
+
+			/* Fill in GitRepository details. */
+			this.setPath(path);
+			this.setFirstParentOnly(true); /* TODO. */
+
+			/* Clone the remote repo. */
+			cloneGitRepository(url, path, bare);
+			hasLocalState = true;
+		} catch (IOException|GitAPIException e) {
+			log.error("Unsuccessful git remote repository initialization", e);
+			throw new RepoDrillerException(e);
 		}
 	}
 
-	protected void initTempGitRepository(boolean bare) throws GitAPIException {
-		File directory = new File(this.tempGitPath);
+	/**
+	 * Clone a git repository.
+	 *
+	 * @param url	Where from?
+	 * @param destination	Where to?
+	 * @param bare	Bare (metadata-only) or full?
+	 * @throws GitAPIException
+	 */
+	private void cloneGitRepository(String url, String destination, boolean bare) throws GitAPIException {
+		File directory = new File(destination);
 
-		if(!directory.exists()) {
-			log.info("Cloning Remote Repository " + this.remoteRepositoryUrl + " into " + this.tempGitPath);
-			Git.cloneRepository()
-					.setURI(this.remoteRepositoryUrl)
-					.setBare(bare)
-					.setDirectory(directory)
-					.setCloneAllBranches(true)
-					.setNoCheckout(false)
-					.call();
-		}
+		if (directory.exists())
+			throw new RepoDrillerException("Error, destination " + destination + " already exists");
+
+		log.info("Cloning Remote Repository " + url + " into " + this.path);
+		Git.cloneRepository()
+				.setURI(url)
+				.setBare(bare)
+				.setDirectory(directory)
+				.setCloneAllBranches(true)
+				.setNoCheckout(false)
+				.call();
 	}
 
-	protected static String gitSystemTempDir() {
-		return FileUtils.getTempDirectory().getAbsolutePath();
+	/**
+	 * Extract a git repo name from its URL.
+	 *
+	 * @param url
+	 * @return
+	 */
+	private static String repoNameFromURL(String url) {
+		/* Examples:
+		 *   git@github.com:substack/node-mkdirp.git
+		 *   https://bitbucket.org/fenics-project/notebooks.git
+		 */
+		int lastSlashIx = url.lastIndexOf("/");
+
+		int lastSuffIx = url.lastIndexOf(URL_SUFFIX);
+		if (lastSuffIx < 0)
+			lastSuffIx = url.length();
+
+		if (lastSlashIx < 0 || lastSuffIx <= lastSlashIx)
+			throw new RepoDrillerException("Error, ill-formed url: " + url);
+
+		return url.substring(lastSlashIx + 1, lastSuffIx);
 	}
 
-	protected static String gitRemoteRepositoryTempDir(String remoteRepositoryUrl, String rootTempDir) {
-		int lastIndexOfDotGit = remoteRepositoryUrl.lastIndexOf(".git");
-		if(lastIndexOfDotGit < 0 )
-			lastIndexOfDotGit = remoteRepositoryUrl.length();
-		String directoryName = remoteRepositoryUrl.substring(remoteRepositoryUrl.lastIndexOf("/")+1, lastIndexOfDotGit);
-
-		if(!rootTempDir.endsWith(File.separator))
-			rootTempDir += File.separator;
-
-		return rootTempDir + directoryName;
+	/**
+	 * Clean up this object.
+	 * See {@link GitRemoteRepository#close}.
+	 *
+	 * @throws IOException
+	 */
+	@Deprecated
+	public void deleteTempGitPath() throws IOException {
+		close();
 	}
+
+	/* Various factory methods. */
 
 	public static SCMRepository singleProject(String url) {
-		return singleProject(url, gitSystemTempDir(), false);
+		return singleProject(url, null, false);
 	}
 
-	protected static SCMRepository singleProject(String url, String rootTempGitPath, boolean bare) {
-		return new GitRemoteRepository(url, rootTempGitPath, bare).info();
+	@SuppressWarnings("resource")
+	public static SCMRepository singleProject(String url, String rootpath, boolean bare) {
+		return new GitRemoteRepository(url, rootpath, bare).info();
 	}
 
-	public static SCMRepository[] allProjectsIn(List<String> urls) {
-		return allProjectsIn(urls, gitSystemTempDir(), false);
+	public static SCMRepository[] allProjectsIn(List<String> urls) throws GitAPIException, IOException {
+		return allProjectsIn(urls, null, false);
 	}
 
-	protected static SCMRepository[] allProjectsIn(List<String> urls, String rootTempGitPath, boolean bare) {
+	protected static SCMRepository[] allProjectsIn(List<String> urls, String rootpath, boolean bare) {
 		List<SCMRepository> repos = new ArrayList<SCMRepository>();
 		for (String url : urls) {
-			repos.add(singleProject(url, rootTempGitPath, bare));
+			repos.add(singleProject(url, rootpath, bare));
 		}
 
 		return repos.toArray(new SCMRepository[repos.size()]);
-	}
-
-	public void deleteTempGitPath() throws IOException {
-		FileUtils.deleteDirectory(new File(this.tempGitPath));
-	}
-
-	@Override
-	public SCMRepository info() {
-		return tempGitRepository.info();
-	}
-
-	@Override
-	public ChangeSet getHead() {
-		return tempGitRepository.getHead();
-	}
-
-	@Override
-	public List<ChangeSet> getChangeSets() {
-		return tempGitRepository.getChangeSets();
-	}
-
-	@Override
-	public Commit getCommit(String id) {
-		return tempGitRepository.getCommit(id);
-	}
-
-	@Override
-	public void checkout(String hash) {
-		tempGitRepository.checkout(hash);
-	}
-
-	@Override
-	public List<RepositoryFile> files() {
-		return tempGitRepository.files();
-	}
-
-	@Override
-	public void reset() {
-		tempGitRepository.reset();
-	}
-
-	@Override
-	public long totalCommits() {
-		return tempGitRepository.totalCommits();
-	}
-
-	@Override
-	@Deprecated
-	public String blame(String file, String currentCommit, Integer line) {
-		return tempGitRepository.blame(file, currentCommit, line);
-	}
-
-	@Override
-	public List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit) {
-		return tempGitRepository.blame(file, commitToBeBlamed, priorCommit);
 	}
 
 	public static SingleGitRemoteRepositoryBuilder hostedOn(String gitUrl) {
@@ -155,9 +167,12 @@ public class GitRemoteRepository implements SCM {
 		return new MultipleGitRemoteRepositoryBuilder(gitUrls);
 	}
 
-	@Override
-	public String getCommitFromTag(String tag) {
-		return tempGitRepository.getCommitFromTag(tag);
-	}
+	/* Interface: AutoCloseable. */
 
+	@Override
+	public void close() throws IOException {
+		if (hasLocalState)
+			FileUtils.deleteDirectory(new File(path));
+		hasLocalState = false;	
+	}
 }

--- a/src/main/java/org/repodriller/scm/RepositoryFile.java
+++ b/src/main/java/org/repodriller/scm/RepositoryFile.java
@@ -2,7 +2,7 @@ package org.repodriller.scm;
 
 import java.io.File;
 
-import org.repodriller.util.FileUtils;
+import org.repodriller.util.RDFileUtils;
 
 public class RepositoryFile {
 
@@ -33,7 +33,7 @@ public class RepositoryFile {
 	}
 	
 	public String getSourceCode() {
-		return FileUtils.readFile(getFile());
+		return RDFileUtils.readFile(getFile());
 	}
 	
 	@Override

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -19,7 +19,7 @@ import org.repodriller.domain.Commit;
 import org.repodriller.domain.Developer;
 import org.repodriller.domain.Modification;
 import org.repodriller.domain.ModificationType;
-import org.repodriller.util.FileUtils;
+import org.repodriller.util.RDFileUtils;
 import org.tmatesoft.svn.core.SVNDepth;
 import org.tmatesoft.svn.core.SVNDirEntry;
 import org.tmatesoft.svn.core.SVNException;
@@ -101,7 +101,7 @@ public class SubversionRepository implements SCM {
 	public static SCMRepository[] allProjectsIn(String path, Integer maxNumberOfFilesInACommit) {
 		List<SCMRepository> repos = new ArrayList<SCMRepository>();
 
-		for (String dir : FileUtils.getAllDirsIn(path)) {
+		for (String dir : RDFileUtils.getAllDirsIn(path)) {
 			repos.add(singleProject(dir, maxNumberOfFilesInACommit));
 		}
 
@@ -320,7 +320,7 @@ public class SubversionRepository implements SCM {
 	}
 
 	private List<File> getAllFilesInPath() {
-		return FileUtils.getAllFilesInPath(workingCopyPath);
+		return RDFileUtils.getAllFilesInPath(workingCopyPath);
 	}
 
 	private boolean isNotAnImportantFile(File f) {

--- a/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
@@ -18,6 +18,10 @@ package org.repodriller.scm.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -39,11 +43,11 @@ public class GitRemoteRepositoryTest {
 	@BeforeClass()
 	public static void readPath() throws InvalidRemoteException, TransportException, GitAPIException, IOException {
 		url = "https://github.com/mauricioaniche/repodriller";
-		
+
 		String toDel = FileUtils.getTempDirectory().getAbsolutePath() + File.separator + "repodriller";
 		FileUtils.deleteDirectory(new File(toDel));
 		git1 = new GitRemoteRepository(url);
-		
+
 		FileUtils.deleteDirectory(new File(REMOTE_GIT_TEMP_DIR + File.separator + "repodriller"));
 		git2 = GitRemoteRepository.hostedOn(url).inTempDir(REMOTE_GIT_TEMP_DIR).asBareRepos().build();
 	}
@@ -53,37 +57,42 @@ public class GitRemoteRepositoryTest {
 		SCMRepository repo = git1.info();
 		Assert.assertEquals("c79c45449201edb2895f48144a3b29cdce7c6f47", repo.getFirstCommit());
 	}
-	
+
 	@Test
 	public void shouldGetSameOriginURL() {
 		SCMRepository repo = git1.info();
 		String origin = repo.getOrigin();
 		Assert.assertEquals(url, origin);
 	}
-	
+
 	@Test
 	public void shouldInitWithGivenTempDir() {
-		String expectedRepoTempDirectory = new File(REMOTE_GIT_TEMP_DIR + File.separator + "repodriller").getAbsolutePath();
-		Assert.assertEquals(expectedRepoTempDirectory, git2.info().getPath());
-		
-		File bareRepositoryRefDir = new File(expectedRepoTempDirectory + File.separator + "refs");
-		Assert.assertTrue("A bare repository should have refs directory.", bareRepositoryRefDir.exists());
+		Path expectedStart = Paths.get(REMOTE_GIT_TEMP_DIR).toAbsolutePath();
+		Assert.assertTrue("Directory " + REMOTE_GIT_TEMP_DIR + " not honored. Path is " + git2.info().getPath(),
+				Paths.get(git2.info().getPath()).startsWith(expectedStart));
+
+		File bareRepositoryRefDir = new File(git2.info().getPath() + File.separator + "refs");
+		Assert.assertTrue("A bare repository should have a refs directory",
+				bareRepositoryRefDir.exists());
 	}
-	
+
 	/**
 	 * Doesn't work in every machine/filesystem.
 	 * Mock to avoid this issue and make test independent of internet connection?
 	 */
+	 /* TODO Should enable this to clean up after running tests. Or otherwise avoid dir pollution, e.g. using the system temp dir as the temp directory rather than putting it in the repodriller tree. */
 //	@AfterClass
 	public static void deleteTempResource() throws IOException {
-		String repoTempPath = git1.info().getPath();
-		git1.deleteTempGitPath();
-		File tempPathDir = new File(repoTempPath);
-		Assert.assertFalse("Temporary directory should be deleted.", tempPathDir.exists());
-		
-		git2.deleteTempGitPath();
-		File givenTempDir = new File(REMOTE_GIT_TEMP_DIR);
-		Assert.assertFalse("Given temporary directory should be deleted.", givenTempDir.exists());
+		Collection<GitRemoteRepository> repos = new ArrayList<GitRemoteRepository>();
+		repos.add(git1);
+		repos.add(git2);
+
+		for (GitRemoteRepository repo : repos) {
+			String repoPath = repo.info().getPath();
+			repo.close();
+			File dir = new File(repoPath);
+			Assert.assertFalse("Remote repo's directory should be deleted: " + repoPath, dir.exists());
+
+		}
 	}
-	
 }

--- a/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRemoteRepositoryTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.repodriller.scm.GitRemoteRepository;
 import org.repodriller.scm.SCMRepository;
@@ -40,15 +41,16 @@ public class GitRemoteRepositoryTest {
 	private static String url;
 	private static String REMOTE_GIT_TEMP_DIR = "remoteGitTempDir";
 
-	@BeforeClass()
+	@BeforeClass
 	public static void readPath() throws InvalidRemoteException, TransportException, GitAPIException, IOException {
 		url = "https://github.com/mauricioaniche/repodriller";
 
-		String toDel = FileUtils.getTempDirectory().getAbsolutePath() + File.separator + "repodriller";
-		FileUtils.deleteDirectory(new File(toDel));
+		/* git1: Clone to a unique temp dir */
 		git1 = new GitRemoteRepository(url);
 
-		FileUtils.deleteDirectory(new File(REMOTE_GIT_TEMP_DIR + File.separator + "repodriller"));
+		/* git2: Clone to relative dir REMOTE_GIT_TEMP_DIR somewhere in the RepoDriller tree.
+		 *       Make sure it doesn't exist when we try to create it. */
+		FileUtils.deleteDirectory(new File(REMOTE_GIT_TEMP_DIR));
 		git2 = GitRemoteRepository.hostedOn(url).inTempDir(REMOTE_GIT_TEMP_DIR).asBareRepos().build();
 	}
 
@@ -68,31 +70,31 @@ public class GitRemoteRepositoryTest {
 	@Test
 	public void shouldInitWithGivenTempDir() {
 		Path expectedStart = Paths.get(REMOTE_GIT_TEMP_DIR).toAbsolutePath();
-		Assert.assertTrue("Directory " + REMOTE_GIT_TEMP_DIR + " not honored. Path is " + git2.info().getPath(),
-				Paths.get(git2.info().getPath()).startsWith(expectedStart));
+		Path absPath = Paths.get(git2.info().getPath()).toAbsolutePath();
+
+		Assert.assertTrue("Directory " + REMOTE_GIT_TEMP_DIR + " not honored. Path is " + absPath,
+			absPath.startsWith(expectedStart));
 
 		File bareRepositoryRefDir = new File(git2.info().getPath() + File.separator + "refs");
 		Assert.assertTrue("A bare repository should have a refs directory",
-				bareRepositoryRefDir.exists());
+			bareRepositoryRefDir.exists());
 	}
 
-	/**
-	 * Doesn't work in every machine/filesystem.
-	 * Mock to avoid this issue and make test independent of internet connection?
-	 */
-	 /* TODO Should enable this to clean up after running tests. Or otherwise avoid dir pollution, e.g. using the system temp dir as the temp directory rather than putting it in the repodriller tree. */
-//	@AfterClass
+	@AfterClass
 	public static void deleteTempResource() throws IOException {
 		Collection<GitRemoteRepository> repos = new ArrayList<GitRemoteRepository>();
-		repos.add(git1);
-		repos.add(git2);
+		if (git1 != null)
+			repos.add(git1);
+		if (git2 != null)
+			repos.add(git2);
 
 		for (GitRemoteRepository repo : repos) {
 			String repoPath = repo.info().getPath();
 			repo.close();
+			/* close() should delete its path. */
 			File dir = new File(repoPath);
-			Assert.assertFalse("Remote repo's directory should be deleted: " + repoPath, dir.exists());
-
+			Assert.assertFalse("Remote repo's directory should be deleted: " + repoPath,
+				dir.exists());
 		}
 	}
 }


### PR DESCRIPTION
Addresses #84.

Problem:
GitRemoteRepository essentially implemented SCM by passing off all the SCM stuff to a GitRepository member.
This resulted in redundant code.

Solution:
GitRemoteRepository now extends GitRepository and implements AutoCloseable.
During construction it clones the repo.
During close it deletes its cloned copy of the repo.
Everything else can be inherited from GitRepository without a problem.

Bonus:
Also includes rename of FileUtils, #83.