### PR TITLE
Getting diffs/modifications between specified commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You simply have to start a Java Project in Eclipse. RepoDriller is on Maven, so 
 	<groupId>org.repodriller</groupId>
 	<artifactId>repodriller</artifactId>
 	<version>1.3.1</version>
-</dependency> 
+</dependency>
 ```
 
 Always use the latest version in Maven. You can see them here: [http://www.mvnrepository.com/artifact/org.repodriller/repodriller](http://www.mvnrepository.com/artifact/org.repodriller/repodriller) . You can also see a [fully function pom.xml example](https://gist.github.com/mauricioaniche/3eba747930aea97e4adb).
@@ -57,7 +57,7 @@ Let's start with something simple: we will print the name of the developers for 
 
 *   in(): We use to configure the project (or projects) that will be analyzed.
 *   through(): The list of commits to analyze. We want all of them. See `Commits` class for a list of available options.
-*   filters(): Possible filters to commits, e.g., only commits in a certain branch 
+*   filters(): Possible filters to commits, e.g., only commits in a certain branch
 *   reverseOrder(): Commits will be analysed in reverse order. Default starts from the first commit to the latest one.
 *   process(): Visitors that will pass in each commit.
 *   mine(): The magic starts!
@@ -85,7 +85,7 @@ public class DevelopersVisitor implements CommitVisitor {
 
 	@Override
 	public void process(SCMRepository repo, Commit commit, PersistenceMechanism writer) {
-		
+
 		writer.write(
 			commit.getHash(),
 			commit.getCommitter().getName()
@@ -124,11 +124,11 @@ pass a flag to the factory:
 
 ```
 GitRepository.single("/your/project", true);
-``` 
+```
 
 ## Logging
 
-RepoDriller uses log4j to print useful information about its execution. 
+RepoDriller uses log4j to print useful information about its execution.
 **Note that this includes Exceptions and their stack traces, which will not appear in standard output.** We recommend you have a log4.xml:
 
 ```xml
@@ -178,10 +178,10 @@ One interesting thing about RepoDriller is that it avoids huge commits. When a c
 RepoDriller comes with a set of common filters that you can apply. As an example, the `OnlyInBranches` filter makes sure
 that your Study will only visit commits which exist in specific branches.
 
-* _OnlyInBranches_: Only visits commits that belong to certain branches. 
+* _OnlyInBranches_: Only visits commits that belong to certain branches.
 * _OnlyInMainBranch_: Only visits commits that belong to the main branch of the repository.
 * _OnlyNoMerge_: Only visits commits that are not merge commits.
-* _OnlyModificationsWithFileTypes_: Only visits commits in which at least one modification was done in that file type, e.g., 
+* _OnlyModificationsWithFileTypes_: Only visits commits in which at least one modification was done in that file type, e.g.,
 if you pass ".java", then, the study will visit only commits in which at least one Java file was modified; clearly, it will skip
 other commits.
 
@@ -190,8 +190,8 @@ You can choose more than one filter as they can be decorated. A working example 
 ```
 .filters(
 	new OnlyModificationsWithFileTypes(Arrays.asList(".java", ".xml")),
-	new OnlyInBranches(Arrays.asList("master")), 
-	new OnlyNoMerge(), 
+	new OnlyInBranches(Arrays.asList("master")),
+	new OnlyNoMerge(),
 	new OnlyInMainBranch()
 );
 ```
@@ -206,7 +206,7 @@ You can get the list of modified files, as well as their diffs and current sourc
 ```java
 @Override
 public void process(SCMRepository repo, Commit commit, PersistenceMechanism writer) {
-	
+
 	for(Modification m : commit.getModifications()) {
 		writer.write(
 				commit.getHash(),
@@ -215,7 +215,7 @@ public void process(SCMRepository repo, Commit commit, PersistenceMechanism writ
 				m.getFileName(),
 				m.getType()
 		);
-		
+
 	}
 }
 ```
@@ -232,7 +232,7 @@ Note about the implementation: This is not supported by JGit, so it makes use of
 
 ## Diffs
 
-Modifications contains _diffs_ from the current version and the last one. This diff is extracted
+Modifications contains _diffs_ between two specified versions. This diff is extracted
 directly from Git output. A common example of the output can be seen below.
 Diffs have their own format (the @@ indicates how you should read it).
 
@@ -242,9 +242,9 @@ index f38a97d..2b96b0e 100644
 --- a/GitRepository.java
 +++ b/GitRepository.java
 @@ -72,7 +72,7 @@ public class GitRepository implements SCM {
- 
+
         private static Logger log = Logger.getLogger(GitRepository.class);
- 
+
 -       public GitRepository(String path) {
 +       public GitRepository2(String path) {
                 this.path = path;
@@ -252,8 +252,18 @@ index f38a97d..2b96b0e 100644
                 this.maxSizeOfDiff = checkMaxSizeOfDiff();
 ```
 
+You can get diffs between two specified revisions that are not necessarily adjacent:
+
+```java
+SCM repo = new GitRepository(path/to/repo);
+List<Modification> modifications = repo.getDiffBetweenCommits(commit1.getHash(), commit2.getHash());
+```
+
+**Note: This has been implemented for Git repositories. Pull requests are welcome for this feature in
+Subversion repositories!**
+
 To facilitate the parsing, RepoDriller offers `DiffParser` class. This utility class parses
-the diff and returns two separate lists: lines (number and content) from the previous version and lines 
+the diff and returns two separate lists: lines (number and content) from the previous version and lines
 from the new version. As one diff may contain different blocks of diffs (happens when the file
 was modified in two parts that are far from each other), the parser returns 1 or more diff blocks.
 
@@ -296,20 +306,20 @@ import org.repodriller.scm.SCMRepository;
 public class ModificationsVisitor implements CommitVisitor {
 
 	private Map<String, Integer> devs;
-	
+
 	public ModificationsVisitor() {
 		this.devs = new HashMap<String, Integer>();
 	}
-	
+
 	@Override
 	public void process(SCMRepository repo, Commit commit, PersistenceMechanism writer) {
-		
+
 		String dev = commit.getCommitter().getName();
 		if(!devs.containsKey(dev)) devs.put(dev, 0);
-		
+
 		int currentFiles = devs.get(dev);
 		devs.put(dev, currentFiles + commit.getModifications().size());
-		
+
 	}
 
 }
@@ -345,32 +355,32 @@ public class JavaParserVisitor implements CommitVisitor {
 
 		try {
 			repo.getScm().checkout(commit.getHash());
-		
+
 			List<RepositoryFile> files = repo.getScm().files();
-			
+
 			for(RepositoryFile file : files) {
 				if(!file.fileNameEndsWith("java")) continue;
-				
+
 				File soFile = file.getFile();
-				
+
 				NumberOfMethodsVisitor visitor = new NumberOfMethodsVisitor();
 				new JDTRunner().visit(visitor, new ByteArrayInputStream(readFile(soFile).getBytes()));
-				
+
 				int methods = visitor.getQty();
-				
+
 				writer.write(
 						commit.getHash(),
 						file.getFullName(),
 						methods
 				);
-				
+
 			}
-			
+
 		} finally {
 			repo.getScm().reset();
 		}
 	}
-	
+
 
 	private String readFile(File f) {
 		try {
@@ -412,7 +422,7 @@ Existing variables:
 
 - *git.maxfiles*: The max quantity of files in a single commit. Commits with more files than this constant
 are ignored. Default is 200.
-  
+
 - *git.maxdiff*: The max number of lines in a diff. Diffs higher than that are ignored. Default is 100000.
 
 - *git.diffcontext*: The size of the content that is used by the diff algorithm. Default is git default.
@@ -427,11 +437,11 @@ are ignored. Default is 200.
 
 ## Using ASTs to parse source code
 
-Repodriller does not come with JDT or any other code parser (as it used to be in old versions). 
-However, it naturally fits with such tools. 
+Repodriller does not come with JDT or any other code parser (as it used to be in old versions).
+However, it naturally fits with such tools.
 
 The [repodriller JDT plugin](https://github.com/mauricioaniche/repodriller-plugin-jdt) adds all
-JDT libraries to your study. 
+JDT libraries to your study.
 If you want to learn more about JDT, check the documentation for [ASTVisitor class](http://help.eclipse.org/juno/index.jsp?topic=%2Forg.eclipse.jdt.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fjdt%2Fcore%2Fdom%2FASTVisitor.html).
 In addition, if you are looking for traditional code metrics
 in Java, you may use our [CK project](https://github.com/mauricioaniche/ck).
@@ -448,7 +458,7 @@ You should read this paper:
 
 # How do I cite RepoDriller?
 
-For now, cite the repository. 
+For now, cite the repository.
 
 # How can I discuss about it?
 
@@ -474,4 +484,3 @@ Then, you can:
 # License
 
 This software is licensed under the Apache 2.0 License.
-

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Note about the implementation: This is not supported by JGit, so it makes use of
 
 ## Diffs
 
-Modifications contains _diffs_ between two specified versions. This diff is extracted
+Modifications contains _diffs_ from the current version and the last one. This diff is extracted
 directly from Git output. A common example of the output can be seen below.
 Diffs have their own format (the @@ indicates how you should read it).
 
@@ -252,7 +252,7 @@ index f38a97d..2b96b0e 100644
                 this.maxSizeOfDiff = checkMaxSizeOfDiff();
 ```
 
-You can get diffs between two specified revisions that are not necessarily adjacent:
+You can also get diffs between two specified revisions that are not necessarily adjacent:
 
 ```java
 SCM repo = new GitRepository(path/to/repo);

--- a/src/main/java/org/repodriller/domain/Commit.java
+++ b/src/main/java/org/repodriller/domain/Commit.java
@@ -89,11 +89,6 @@ public class Commit {
 		modifications.add(m);
 	}
 
-	public void addModification(String oldPath, String newPath, ModificationType change, String diff, String sc) {
-		Modification m = new Modification(oldPath, newPath, change, diff, sc);
-		modifications.add(m);
-	}
-
 	public void addModifications(List<Modification> modifications) {
 		this.modifications.addAll(modifications);
 	}

--- a/src/main/java/org/repodriller/domain/Commit.java
+++ b/src/main/java/org/repodriller/domain/Commit.java
@@ -89,6 +89,11 @@ public class Commit {
 		modifications.add(m);
 	}
 
+	public void addModification(String oldPath, String newPath, ModificationType change, String diff, String sc) {
+		Modification m = new Modification(oldPath, newPath, change, diff, sc);
+		modifications.add(m);
+	}
+
 	public void addModifications(List<Modification> modifications) {
 		this.modifications.addAll(modifications);
 	}

--- a/src/main/java/org/repodriller/scm/GitRemoteRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRemoteRepository.java
@@ -181,6 +181,6 @@ public class GitRemoteRepository extends GitRepository implements AutoCloseable 
 	public void close() throws IOException {
 		if (hasLocalState)
 			FileUtils.deleteDirectory(new File(path));
-		hasLocalState = false;	
+		hasLocalState = false;
 	}
 }

--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -154,15 +154,18 @@ public class GitRepository implements SCM {
 	}
 
 	public ChangeSet getHead() {
+		RevWalk revWalk = null;
         try (Git git = openRepository()) {
 			ObjectId head = git.getRepository().resolve(Constants.HEAD);
 
-			RevWalk revWalk = new RevWalk(git.getRepository());
+			revWalk = new RevWalk(git.getRepository());
 			RevCommit r = revWalk.parseCommit(head);
 			return new ChangeSet(r.getName(), convertToDate(r));
 
 		} catch (Exception e) {
 			throw new RuntimeException("error in getHead() for " + path, e);
+		} finally {
+			revWalk.close();
 		}
 	}
 
@@ -180,10 +183,11 @@ public class GitRepository implements SCM {
 	}
 
 	private List<ChangeSet> firstParentsOnly(Git git) {
+		RevWalk revWalk = null;
 		try {
 			List<ChangeSet> allCs = new ArrayList<>();
 
-			RevWalk revWalk = new RevWalk(git.getRepository());
+			revWalk = new RevWalk(git.getRepository());
 			revWalk.setRevFilter(new FirstParentFilter());
 			revWalk.sort(RevSort.TOPO);
 			Ref headRef = git.getRepository().getRef(Constants.HEAD);  /* TODO Deprecated. */
@@ -197,6 +201,8 @@ public class GitRepository implements SCM {
 
 		} catch (Exception e) {
 			throw new RuntimeException(e);
+		} finally {
+			revWalk.close();
 		}
 	}
 

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
+import org.repodriller.domain.Modification;
 
 /**
  * This interface defines interactions with a source code repository that uses a Source Code Management system (i.e. version control system).
@@ -68,7 +69,7 @@ public interface SCM {
 	Commit getCommit(String id);
 	/* TODO A method named getCommitXYZ should return a Commit. */
 	String getCommitFromTag(String tag);
-	void getDiffBetweenCommits(String priorCommit, String laterCommit);
+	List<Modification> getDiffBetweenCommits(String priorCommit, String laterCommit);
 	@Deprecated
 	String blame(String file, String currentCommit, Integer line);
 	List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit);

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -69,7 +69,17 @@ public interface SCM {
 	Commit getCommit(String id);
 	/* TODO A method named getCommitXYZ should return a Commit. */
 	String getCommitFromTag(String tag);
+	
+	/**
+	 * Get the diff between the specified commits.
+	 * 
+	 * @param priorCommit	The first (old) commit
+	 * @param laterCommit	The second (new) commit
+	 * @return A list of Modification objects representing the changes between
+	 * 			priorCommit and laterCommit.
+	 */
 	List<Modification> getDiffBetweenCommits(String priorCommit, String laterCommit);
+	
 	@Deprecated
 	String blame(String file, String currentCommit, Integer line);
 	List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit);

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -68,7 +68,6 @@ public interface SCM {
 	Commit getCommit(String id);
 	/* TODO A method named getCommitXYZ should return a Commit. */
 	String getCommitFromTag(String tag);
-
 	@Deprecated
 	String blame(String file, String currentCommit, Integer line);
 	List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit);

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -68,6 +68,7 @@ public interface SCM {
 	Commit getCommit(String id);
 	/* TODO A method named getCommitXYZ should return a Commit. */
 	String getCommitFromTag(String tag);
+	void getDiffBetweenCommits(String priorCommit, String laterCommit);
 	@Deprecated
 	String blame(String file, String currentCommit, Integer line);
 	List<BlamedLine> blame(String file, String commitToBeBlamed, boolean priorCommit);

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -266,6 +266,11 @@ public class SubversionRepository implements SCM {
 			return "";
 		}
 	}
+	
+	@Override
+	public void getDiffBetweenCommits(String priorCommit, String laterCommit) {
+		// TODO Auto-generated method stub	
+	}
 
 	private ModificationType getModificationType(SVNLogEntryPath e) {
 		if (e.getType() == 'A') {

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -268,8 +268,9 @@ public class SubversionRepository implements SCM {
 	}
 	
 	@Override
-	public void getDiffBetweenCommits(String priorCommit, String laterCommit) {
-		// TODO Auto-generated method stub	
+	public List<Modification> getDiffBetweenCommits(String priorCommit, String laterCommit) {
+		// TODO Not yet implemented for SVN.
+		return new ArrayList<Modification>();
 	}
 
 	private ModificationType getModificationType(SVNLogEntryPath e) {

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
+import org.repodriller.RepoDrillerException;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
 import org.repodriller.domain.Developer;
@@ -270,7 +271,7 @@ public class SubversionRepository implements SCM {
 	@Override
 	public List<Modification> getDiffBetweenCommits(String priorCommit, String laterCommit) {
 		// TODO Not yet implemented for SVN.
-		return new ArrayList<Modification>();
+		throw new RepoDrillerException("This feature has not yet been implemented for Subversion repos.");
 	}
 
 	private ModificationType getModificationType(SVNLogEntryPath e) {

--- a/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
@@ -25,6 +25,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.repodriller.domain.ChangeSet;
 import org.repodriller.domain.Commit;
+import org.repodriller.domain.Modification;
 import org.repodriller.domain.ModificationType;
 import org.repodriller.scm.BlamedLine;
 import org.repodriller.scm.GitRepository;
@@ -275,6 +276,38 @@ public class GitRepositoryTest {
 		Assert.assertTrue(changeSets.stream().anyMatch(x -> x.getId().equals("80c6a1123d60a021c41d2581f8fbf6cfc2e38977")));
 		Assert.assertTrue(changeSets.stream().anyMatch(x -> x.getId().equals("7a58b021f41b96a73d1383bb5e4e0feab1861327")));
 		Assert.assertTrue(changeSets.stream().anyMatch(x -> x.getId().equals("933b2c6a6be916546d13b684d3201de6d3bc4058")));
+	}
+	
+	@Test
+	public void shouldReturnDiffBetweenCommitsWithOneModification() {
+		String priorCommitHash = "71535a3";
+		String laterCommitHash = "953737b";
+		List<Modification> modifications = git1.getDiffBetweenCommits(priorCommitHash, laterCommitHash);
+		Assert.assertEquals(1, modifications.size());
+		Assert.assertEquals(ModificationType.MODIFY, modifications.get(0).getType());
+		Assert.assertEquals(3, modifications.get(0).getAdded());
+		Assert.assertEquals(0, modifications.get(0).getRemoved());
+		Assert.assertEquals("Matricula.java", modifications.get(0).getFileName());
+	}
+	
+	@Test
+	public void shouldReturnDiffWithManyModifications() {
+		String priorCommitHash = "8b17577";
+		String laterCommitHash = "f0dd130";
+		List<Modification> modifications = git3.getDiffBetweenCommits(priorCommitHash, laterCommitHash);
+		Assert.assertEquals(3, modifications.size());
+		
+		Modification first = modifications.get(0);
+		Assert.assertEquals(ModificationType.DELETE, first.getType());
+		Assert.assertEquals("Aluno.java", first.getFileName());
+		
+		Modification second = modifications.get(1);
+		Assert.assertEquals(ModificationType.RENAME, second.getType());
+		Assert.assertEquals(17, second.getAdded());
+		
+		Modification third = modifications.get(2);
+		Assert.assertEquals(ModificationType.ADD, third.getType());
+		Assert.assertEquals(52, third.getAdded());
 	}
 	
 	@Test


### PR DESCRIPTION
Related to: #87 

### Adds functionality to `SCM` and its implementing classes

Given two commit hashes, return the diff between the two commits in the form of a `List<Modification>`.  **Only implemented in `GitRepository`**. Calling it in `SubversionRepository` will throw a `RepoDrillerException`.