### PR TITLE
Make ChangeSet more full-featured

### DIFF
--- a/src/main/java/org/repodriller/domain/ChangeSet.java
+++ b/src/main/java/org/repodriller/domain/ChangeSet.java
@@ -16,45 +16,88 @@
 
 package org.repodriller.domain;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * A ChangeSet is metadata that uniquely identifies a Commit from an SCM.
- *
- * @author Mauricio Aniche
+ * A ChangeSet is metadata about a Commit from an SCM.
+ * It's "everything but the diff".
  */
 public class ChangeSet {
 
-	private final Calendar date;
-	private final String id;
+	private String id; /* Unique within an SCM. */
+	private String message;
 
-	public ChangeSet(String id, Calendar date) {
+	private CommitPerson author; /* Person who committed it. */
+	private CommitPerson committer; /* Person who merged it. This is probably the field you want. */
+
+	public ChangeSet(String id, String message, CommitPerson author) {
 		this.id = id;
-		this.date = date;
+		this.message = message;
+
+		this.author = author;
+		this.committer = this.author;
+	}
+
+	public ChangeSet(String id, String message, CommitPerson author, CommitPerson committer) {
+		this.id = id;
+		this.message = message;
+
+		this.author = author;
+		this.committer = committer;
 	}
 
 	/**
-	 * @return The time at which this ChangeSet was created by a developer
-	 */
-	public Calendar getTime() {
-		return date;
-	}
-
-	/**
-	 * @return The id of this ChangeSet in its SCM
+	 * @return Unique ID within SCM
 	 */
 	public String getId() {
 		return id;
 	}
 
+	/**
+	 * @return Commit message
+	 */
+	public String getMessage() {
+		return message;
+	}
+
+	/**
+	 * How the ChangeSet was created.
+	 *
+	 * @return Person who authored the commit. See {@link ChangeSet#getCommitter}.
+	 */
+	public CommitPerson getAuthor() {
+		return author;
+	}
+
+	/**
+	 * How the ChangeSet entered the codebase, e.g. when a PR is accepted.
+	 *
+	 * @return Person who merged the commit.
+	 */
+	public CommitPerson getCommitter() {
+		return committer;
+	}
+
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((date == null) ? 0 : date.hashCode());
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
+		final int prime1 = 17;
+		final int prime2 = 31;
+
+		int hash = prime1;
+
+		/* I'm sure there's a more efficient way to do this... */
+		List<Object> members = new ArrayList<Object>();
+		members.add(id);
+		members.add(message);
+		members.add(author);
+		members.add(committer);
+
+		for (Object member : members) {
+			hash = prime2*hash + ((member == null) ? 0 : member.hashCode());
+		}
+
+		return hash;
 	}
 
 	@Override
@@ -69,24 +112,27 @@ public class ChangeSet {
 
 		/* Compare two distinct instances. */
 		ChangeSet other = (ChangeSet) obj;
-		if (date == null) {
-			if (other.date != null)
-				return false;
-		} else if (!date.equals(other.date))
-			return false;
 
 		if (id == null) {
 			if (other.id != null)
 				return false;
-		} else if (!id.equals(other.id))
-			return false;
+		}
+		else {
+			if (!id.equals(other.id))
+				return false;
+		}
 
 		return true;
 	}
 
 	@Override
 	public String toString() {
-		return "[" + id + ", " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(date.getTime()) + "]";
+		if (author.equals(committer)) {
+			return String.format("%s: author %s", id, author);
+		}
+		else {
+			return String.format("%s: author %s, committer %s", id, author, committer);
+		}
 	}
 
 }

--- a/src/main/java/org/repodriller/domain/CommitPerson.java
+++ b/src/main/java/org/repodriller/domain/CommitPerson.java
@@ -1,0 +1,95 @@
+package org.repodriller.domain;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+/**
+ * A POJO to track details about a person involved with a commit.
+ */
+public class CommitPerson {
+	public String name;
+	public String email;
+	public Calendar time;
+
+	public CommitPerson(String author, String email, Calendar time) {
+		this.name = author;
+		this.email = email;
+		this.time = time;
+	}
+
+	public CommitPerson(CommitPerson c) {
+		this.name = c.name;
+		this.email = c.email;
+		this.time = c.time;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s <%s> at %s",  name, email, new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(time));
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime1 = 17;
+		final int prime2 = 31;
+
+		int hash = prime1;
+
+		/* I'm sure there's a more efficient way to do this... */
+		List<Object> members = new ArrayList<Object>();
+		members.add(name);
+		members.add(email);
+		members.add(time);
+
+		for (Object member : members) {
+			hash = prime2*hash + ((member == null) ? 0 : member.hashCode());
+		}
+
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		/* Boilerplate. */
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+
+		/* Compare two distinct instances. */
+		CommitPerson other = (CommitPerson) obj;
+
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		}
+		else {
+			if (!name.equals(other.name))
+				return false;
+		}
+
+		if (email == null) {
+			if (other.email != null)
+				return false;
+		}
+		else {
+			if (!email.equals(other.name))
+				return false;
+		}
+
+		if (time == null) {
+			if (other.time != null)
+				return false;
+		}
+		else {
+			if (!time.equals(other.name))
+				return false;
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/org/repodriller/filter/range/BetweenDates.java
+++ b/src/main/java/org/repodriller/filter/range/BetweenDates.java
@@ -8,7 +8,7 @@ import org.repodriller.domain.ChangeSet;
 import org.repodriller.scm.SCM;
 
 public class BetweenDates implements CommitRange {
-	
+
 	private Calendar from;
 	private Calendar to;
 
@@ -19,22 +19,22 @@ public class BetweenDates implements CommitRange {
 
 	@Override
 	public List<ChangeSet> get(SCM scm) {
-		
+
 		List<ChangeSet> all = scm.getChangeSets();
-		
+
 		LinkedList<ChangeSet> filtered = new LinkedList<ChangeSet>();
-		
+
 		for(ChangeSet cs : all) {
 			if(isInTheRange(cs)) {
 				filtered.addLast(cs);
 			}
 		}
-		
+
 		return filtered;
 	}
 
 	private boolean isInTheRange(ChangeSet cs) {
-		return from.before(cs.getTime()) && to.after(cs.getTime());
+		return from.before(cs.getCommitter().time) && to.after(cs.getCommitter().time);
 	}
 
 

--- a/src/main/java/org/repodriller/filter/range/CommitRange.java
+++ b/src/main/java/org/repodriller/filter/range/CommitRange.java
@@ -6,7 +6,7 @@ import org.repodriller.domain.ChangeSet;
 import org.repodriller.scm.SCM;
 
 /**
- * Return a set of commits from an SCM.
+ * A CommitRange is a subset of all commits from the SCM, returned in the order in which they should be processed.
  *
  * @author Mauricio Aniche
  */

--- a/src/main/java/org/repodriller/filter/range/LastMonths.java
+++ b/src/main/java/org/repodriller/filter/range/LastMonths.java
@@ -18,20 +18,20 @@ public class LastMonths implements CommitRange {
 
 	@Override
 	public List<ChangeSet> get(SCM scm) {
-		
+
 		LinkedList<ChangeSet> filtered = new LinkedList<ChangeSet>();
 		List<ChangeSet> all = scm.getChangeSets();
-		
-		sixMonthsAgo = all.get(0).getTime();
+
+		sixMonthsAgo = all.get(0).getCommitter().time;
 		sixMonthsAgo.add(Calendar.MONTH, -months);
 		filtered.add(all.get(0));
-		
+
 		for(ChangeSet cs : all) {
-			if(cs.getTime().after(sixMonthsAgo)) {
+			if(cs.getCommitter().time.after(sixMonthsAgo)) {
 				filtered.addLast(cs);
 			}
 		}
-		
+
 		return filtered;
 	}
 

--- a/src/main/java/org/repodriller/filter/range/MonthlyCommits.java
+++ b/src/main/java/org/repodriller/filter/range/MonthlyCommits.java
@@ -11,34 +11,34 @@ public class MonthlyCommits implements CommitRange {
 	private final long monthsInMillis;
 
 	public MonthlyCommits(int months) {
-		monthsInMillis = 1000L * 60L * 60L * 24L * 30L * (long) months;
+		monthsInMillis = 1000L * 60L * 60L * 24L * 30L * months;
 	}
 
 	@Override
 	public List<ChangeSet> get(SCM scm) {
-		
+
 		List<ChangeSet> all = scm.getChangeSets();
-		
+
 		LinkedList<ChangeSet> filtered = new LinkedList<ChangeSet>();
 		filtered.add(all.get(0));
-		
+
 		for(ChangeSet cs : all) {
 			if(isFarFromTheLastOne(cs, filtered)) {
 				filtered.addLast(cs);
 			}
 		}
-		
+
 		return filtered;
 	}
 
 	private boolean isFarFromTheLastOne(ChangeSet cs, LinkedList<ChangeSet> filtered) {
 		ChangeSet lastOne = filtered.getLast();
-		
-		long lastInMillis = lastOne.getTime().getTimeInMillis();
-		long currentInMillis = cs.getTime().getTimeInMillis();
-		
+
+		long lastInMillis = lastOne.getCommitter().time.getTimeInMillis();
+		long currentInMillis = cs.getCommitter().time.getTimeInMillis();
+
 		return (lastInMillis - currentInMillis >= monthsInMillis);
 	}
-	
-	
+
+
 }

--- a/src/main/java/org/repodriller/filter/range/SinceCommit.java
+++ b/src/main/java/org/repodriller/filter/range/SinceCommit.java
@@ -8,7 +8,7 @@ import org.repodriller.domain.ChangeSet;
 import org.repodriller.scm.SCM;
 
 public class SinceCommit implements CommitRange {
-	
+
 	private Calendar since;
 
 	public SinceCommit(Calendar since) {
@@ -17,22 +17,22 @@ public class SinceCommit implements CommitRange {
 
 	@Override
 	public List<ChangeSet> get(SCM scm) {
-		
+
 		List<ChangeSet> all = scm.getChangeSets();
-		
+
 		LinkedList<ChangeSet> filtered = new LinkedList<ChangeSet>();
-		
+
 		for(ChangeSet cs : all) {
 			if(isInTheRange(cs)) {
 				filtered.addLast(cs);
 			}
 		}
-		
+
 		return filtered;
 	}
 
 	private boolean isInTheRange(ChangeSet cs) {
-		return since.before(cs.getTime());
+		return since.before(cs.getCommitter().time);
 	}
 
 

--- a/src/main/java/org/repodriller/scm/SCM.java
+++ b/src/main/java/org/repodriller/scm/SCM.java
@@ -48,7 +48,7 @@ public interface SCM {
 	ChangeSet getHead();
 
 	/**
-	 * @return All ChangeSets in this SCM.
+	 * @return All ChangeSets in this SCM. Probably with the newest ChangeSet at the front of the list.
 	 */
 	List<ChangeSet> getChangeSets();
 

--- a/src/test/java/org/repodriller/filter/range/BetweenDatesTest.java
+++ b/src/test/java/org/repodriller/filter/range/BetweenDatesTest.java
@@ -10,38 +10,37 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
-import org.repodriller.filter.range.BetweenDates;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
 
 public class BetweenDatesTest {
 
 	private BetweenDates range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_commits_in_range() {
-		range = new BetweenDates(
-				new GregorianCalendar(2016, Calendar.JANUARY, 01),
-				new GregorianCalendar(2016, Calendar.DECEMBER, 31));
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2016, Calendar.APRIL, 25));
-		ChangeSet c4 = new ChangeSet("4", new GregorianCalendar(2016, Calendar.APRIL, 25));
-		ChangeSet c5 = new ChangeSet("5", new GregorianCalendar(2017, Calendar.APRIL, 25));
-		
+		range = new BetweenDates(new GregorianCalendar(2016, Calendar.JANUARY, 01),
+								new GregorianCalendar(2016, Calendar.DECEMBER, 31));
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2016, Calendar.APRIL, 25)));
+		ChangeSet c4 = new ChangeSet("4", "", new CommitPerson("", "", new GregorianCalendar(2016, Calendar.APRIL, 25)));
+		ChangeSet c5 = new ChangeSet("5", "", new CommitPerson("", "", new GregorianCalendar(2017, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3, c4, c5));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(2, list.size());
 		Assert.assertTrue(list.contains(c3));
 		Assert.assertTrue(list.contains(c4));
 	}
-	
+
 }

--- a/src/test/java/org/repodriller/filter/range/LastMonthsTest.java
+++ b/src/test/java/org/repodriller/filter/range/LastMonthsTest.java
@@ -5,53 +5,53 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
-import org.repodriller.filter.range.LastMonths;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
-import org.junit.Assert;
 
 public class LastMonthsTest {
 
 	private LastMonths range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		range = new LastMonths(6);
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_all_commits_until_number_of_months() {
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2015, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(3, list.size());
 		Assert.assertEquals(c1, list.get(0));
 		Assert.assertEquals(c2, list.get(1));
 		Assert.assertEquals(c3, list.get(2));
 	}
-	
+
 	@Test
 	public void should_not_all_commits_after_number_of_months() {
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2014, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2014, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(2, list.size());
 		Assert.assertEquals(c1, list.get(0));
 		Assert.assertEquals(c2, list.get(1));

--- a/src/test/java/org/repodriller/filter/range/ListOfCommitsTest.java
+++ b/src/test/java/org/repodriller/filter/range/ListOfCommitsTest.java
@@ -10,37 +10,37 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
-import org.repodriller.filter.range.ListOfCommits;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
 
 public class ListOfCommitsTest {
 
 	private ListOfCommits range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_commits_in_range() {
 		range = new ListOfCommits(Arrays.asList("2", "3", "4"));
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2015, Calendar.APRIL, 25));
-		ChangeSet c4 = new ChangeSet("4", new GregorianCalendar(2014, Calendar.APRIL, 25));
-		ChangeSet c5 = new ChangeSet("5", new GregorianCalendar(2013, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.APRIL, 25)));
+		ChangeSet c4 = new ChangeSet("4", "", new CommitPerson("", "", new GregorianCalendar(2014, Calendar.APRIL, 25)));
+		ChangeSet c5 = new ChangeSet("5", "", new CommitPerson("", "", new GregorianCalendar(2013, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3, c4, c5));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(3, list.size());
 		Assert.assertEquals(c2, list.get(0));
 		Assert.assertEquals(c3, list.get(1));
 		Assert.assertEquals(c4, list.get(2));
 	}
-	
+
 }

--- a/src/test/java/org/repodriller/filter/range/RangeTest.java
+++ b/src/test/java/org/repodriller/filter/range/RangeTest.java
@@ -10,33 +10,33 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
-import org.repodriller.filter.range.Range;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
 
 public class RangeTest {
 
 	private Range range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_commits_in_range() {
 		range = new Range("2", "4");
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2015, Calendar.APRIL, 25));
-		ChangeSet c4 = new ChangeSet("4", new GregorianCalendar(2014, Calendar.APRIL, 25));
-		ChangeSet c5 = new ChangeSet("5", new GregorianCalendar(2013, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.APRIL, 25)));
+		ChangeSet c4 = new ChangeSet("4", "", new CommitPerson("", "", new GregorianCalendar(2014, Calendar.APRIL, 25)));
+		ChangeSet c5 = new ChangeSet("5", "", new CommitPerson("", "", new GregorianCalendar(2013, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3, c4, c5));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(3, list.size());
 		Assert.assertEquals(c2, list.get(0));
 		Assert.assertEquals(c3, list.get(1));
@@ -46,21 +46,21 @@ public class RangeTest {
 	@Test
 	public void should_get_commits_in_range_even_if_list_is_upside_down() {
 		range = new Range("2", "4");
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2015, Calendar.APRIL, 25));
-		ChangeSet c4 = new ChangeSet("4", new GregorianCalendar(2014, Calendar.APRIL, 25));
-		ChangeSet c5 = new ChangeSet("5", new GregorianCalendar(2013, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.APRIL, 25)));
+		ChangeSet c4 = new ChangeSet("4", "", new CommitPerson("", "", new GregorianCalendar(2014, Calendar.APRIL, 25)));
+		ChangeSet c5 = new ChangeSet("5", "", new CommitPerson("", "", new GregorianCalendar(2013, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c5, c4, c3, c2, c1));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(3, list.size());
 		Assert.assertEquals(c4, list.get(0));
 		Assert.assertEquals(c3, list.get(1));
 		Assert.assertEquals(c2, list.get(2));
 	}
-	
+
 }

--- a/src/test/java/org/repodriller/filter/range/SinceCommitTest.java
+++ b/src/test/java/org/repodriller/filter/range/SinceCommitTest.java
@@ -10,36 +10,37 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
 
 public class SinceCommitTest {
 
 	private SinceCommit range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_commits_in_range() {
 		range = new SinceCommit(
 				new GregorianCalendar(2016, Calendar.MAY, 20));
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2016, Calendar.APRIL, 25));
-		ChangeSet c4 = new ChangeSet("4", new GregorianCalendar(2016, Calendar.MAY, 25));
-		ChangeSet c5 = new ChangeSet("5", new GregorianCalendar(2017, Calendar.JUNE, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2016, Calendar.APRIL, 25)));
+		ChangeSet c4 = new ChangeSet("4", "", new CommitPerson("", "", new GregorianCalendar(2016, Calendar.MAY, 25)));
+		ChangeSet c5 = new ChangeSet("5", "", new CommitPerson("", "", new GregorianCalendar(2017, Calendar.JUNE, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3, c4, c5));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(2, list.size());
 		Assert.assertTrue(list.contains(c4));
 		Assert.assertTrue(list.contains(c5));
 	}
-	
+
 }

--- a/src/test/java/org/repodriller/filter/range/SingleCommitTest.java
+++ b/src/test/java/org/repodriller/filter/range/SingleCommitTest.java
@@ -10,33 +10,33 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.repodriller.domain.ChangeSet;
-import org.repodriller.filter.range.SingleCommit;
+import org.repodriller.domain.CommitPerson;
 import org.repodriller.scm.SCM;
 
 public class SingleCommitTest {
 
 	private SingleCommit range;
 	private SCM scm;
-	
+
 	@Before
 	public void setUp() {
 		scm = Mockito.mock(SCM.class);
 	}
-	
+
 	@Test
 	public void should_get_specific_commits() {
 		range = new SingleCommit("2");
-		
-		ChangeSet c1 = new ChangeSet("1", new GregorianCalendar(2015, Calendar.JANUARY, 23));
-		ChangeSet c2 = new ChangeSet("2", new GregorianCalendar(2015, Calendar.MARCH, 24));
-		ChangeSet c3 = new ChangeSet("3", new GregorianCalendar(2015, Calendar.APRIL, 25));
-		
+
+		ChangeSet c1 = new ChangeSet("1", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.JANUARY, 23)));
+		ChangeSet c2 = new ChangeSet("2", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.MARCH, 24)));
+		ChangeSet c3 = new ChangeSet("3", "", new CommitPerson("", "", new GregorianCalendar(2015, Calendar.APRIL, 25)));
+
 		Mockito.when(scm.getChangeSets()).thenReturn(Arrays.asList(c1, c2, c3));
-		
+
 		List<ChangeSet> list = range.get(scm);
-		
+
 		Assert.assertEquals(1, list.size());
 		Assert.assertEquals(c2, list.get(0));
 	}
-	
+
 }


### PR DESCRIPTION
A Changeset now includes a message as well as author/committer objects
modeled on JGit's PersonIdent.

This is a breaking change for anyone who uses ChangeSet.
The payoff is that on complex git-based repositories, users can now better handle the distributed nature of git.

The time-based CommitRanges provided by RepoDriller now use the committer time when doing time comparisons.
This is what the user generally intends: "the time at which this commit entered the repository".

Addresses #96.