### PR TITLE
Provide both parents of a merge commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ the `shouldAccept()` method. This method should only return **true** if the comm
 
 You can get the list of modified files, as well as their diffs and current source code. To that, all you have to do is to get the list of _Modification_s that exists inside _Commit_.
 
-A _Commit_ contains a hash, a committer (name and email), an author (name, and email) a message, the date, a list of its parent hashes (if it' a merge commit, the commit has two parents), and the list of modification.
+A _Commit_ contains a hash, a committer (name and email), an author (name, and email) a message, the date, a list of its parent hashes (if it's a merge commit, the commit has two parents), and the list of modification.
 
 _(Due to backwards compatibility, the `getParent()` method returns the first parent hash only. Use `getParents()` to get both parents.)_
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,11 @@ the `shouldAccept()` method. This method should only return **true** if the comm
 
 ## Getting Modifications
 
-You can get the list of modified files, as well as their diffs and current source code. To that, all you have to do is to get the list of _Modification_s that exists inside _Commit_. A _Commit_ contains a hash, a committer (name and email), an author (name, and email) a message, the date, its parent hash, and the list of modification.
+You can get the list of modified files, as well as their diffs and current source code. To that, all you have to do is to get the list of _Modification_s that exists inside _Commit_.
+
+A _Commit_ contains a hash, a committer (name and email), an author (name, and email) a message, the date, a list of its parent hashes (if it' a merge commit, the commit has two parents), and the list of modification.
+
+_(Due to backwards compatibility, the `getParent()` method returns the first parent hash only. Use `getParents()` to get both parents.)_
 
 ```java
 @Override

--- a/src/main/java/org/repodriller/domain/Commit.java
+++ b/src/main/java/org/repodriller/domain/Commit.java
@@ -32,7 +32,7 @@ public class Commit {
 	private Developer committer;
 	private String msg;
 	private List<Modification> modifications;
-	private String parent;
+	private List<String> parents;
 	private Calendar date;
 	private Set<String> branches;
 	private boolean merge;
@@ -41,18 +41,20 @@ public class Commit {
 	private TimeZone committerTimeZone;
 	private Calendar committerDate;
 
-	public Commit(String hash, Developer author, Developer committer, Calendar authorDate, Calendar committerDate, String msg, String parent) {
-		this(hash, author, committer, authorDate, TimeZone.getDefault(), committerDate, TimeZone.getDefault(), msg, parent, false, new HashSet<>(), false);
+	public Commit(String hash, Developer author, Developer committer, Calendar authorDate, Calendar committerDate, String msg, List<String> parents) {
+		this(hash, author, committer, authorDate, TimeZone.getDefault(), committerDate, TimeZone.getDefault(), msg, parents, false, new HashSet<>(), false);
 	}
 
-	public Commit(String hash, Developer author, Developer committer, Calendar authorDate, TimeZone authorTimeZone, Calendar committerDate, TimeZone committerTimeZone, String msg, String parent, boolean merge, Set<String> branches, boolean isCommitInMainBranch) {
+	public Commit(String hash, Developer author, Developer committer, Calendar authorDate, TimeZone authorTimeZone, Calendar committerDate, TimeZone committerTimeZone, String msg, List<String> parents, boolean merge, Set<String> branches, boolean isCommitInMainBranch) {
 		this.hash = hash;
 		this.author = author;
 		this.committer = committer;
 		this.date = authorDate;
 		this.committerDate = committerDate;
 		this.msg = msg;
-		this.parent = parent;
+		this.parents = parents;
+		if(this.parents == null)
+			parents = new ArrayList<>();
 		this.merge = merge;
 		this.authorTimeZone = authorTimeZone;
 		this.committerTimeZone = committerTimeZone;
@@ -81,8 +83,16 @@ public class Commit {
 		return committer;
 	}
 
+	/**
+	 * Here to keep compatibility with previous versions
+	 * @return the hash of the commit's first parent
+	 */
 	public String getParent() {
-		return parent;
+		return parents.isEmpty() ? "" : parents.get(0);
+	}
+
+	public List<String> getParents () {
+		return Collections.unmodifiableList(parents);
 	}
 
 	public void addModification(Modification m) {
@@ -103,7 +113,7 @@ public class Commit {
 
 	@Override
 	public String toString() {
-		return "Commit [hash=" + hash + ", parent=" + parent + ", author=" + author + ", msg=" + msg + ", modifications="
+		return "Commit [hash=" + hash + ", parents=" + parents + ", author=" + author + ", msg=" + msg + ", modifications="
 				+ modifications + "]";
 	}
 

--- a/src/main/java/org/repodriller/domain/Commit.java
+++ b/src/main/java/org/repodriller/domain/Commit.java
@@ -87,6 +87,7 @@ public class Commit {
 	 * Here to keep compatibility with previous versions
 	 * @return the hash of the commit's first parent
 	 */
+	@Deprecated
 	public String getParent() {
 		return parents.isEmpty() ? "" : parents.get(0);
 	}

--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -21,12 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.GregorianCalendar;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -266,7 +261,8 @@ public class GitRepository implements SCM {
 
 			String msg = jgitCommit.getFullMessage().trim();
 			String hash = jgitCommit.getName().toString();
-			String parent = (jgitCommit.getParentCount() > 0) ? jgitCommit.getParent(0).getName().toString() : "";
+			List<String> parents = Arrays.stream(jgitCommit.getParents())
+					.map(rc -> rc.getName().toString()).collect(Collectors.toList());
 
 			GregorianCalendar authorDate = new GregorianCalendar();
 			authorDate.setTime(jgitCommit.getAuthorIdent().getWhen());
@@ -282,7 +278,7 @@ public class GitRepository implements SCM {
 			boolean isCommitInMainBranch = branches.contains(this.mainBranchName);
 
 			/* Create one of our Commit's based on the jgitCommit metadata. */
-			Commit commit = new Commit(hash, author, committer, authorDate, authorTimeZone, committerDate, committerTimeZone, msg, parent, isMerge, branches, isCommitInMainBranch);
+			Commit commit = new Commit(hash, author, committer, authorDate, authorTimeZone, committerDate, committerTimeZone, msg, parents, isMerge, branches, isCommitInMainBranch);
 
 			/* Convert each of the associated DiffEntry's to a Modification. */
 			List<DiffEntry> diffsForTheCommit = diffsForTheCommit(repo, jgitCommit);

--- a/src/main/java/org/repodriller/scm/SubversionRepository.java
+++ b/src/main/java/org/repodriller/scm/SubversionRepository.java
@@ -217,7 +217,7 @@ public class SubversionRepository implements SCM {
 		Developer committer = new Developer(logEntry.getAuthor(), null);
 		Calendar date = convertToCalendar(logEntry.getDate());
 		Commit commit = new Commit(String.valueOf(logEntry.getRevision()), null, committer, date, date, logEntry.getMessage(),
-				"");
+				null);
 		return commit;
 	}
 

--- a/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
@@ -37,19 +37,24 @@ public class GitRepositoryTest {
 	private GitRepository git1;
 	private GitRepository git2;
 	private GitRepository git3;
+	private GitRepository git5;
 	private GitRepository git6;
 	private GitRepository git8;
+
 	private static String path1;
 	private static String path2;
 	private static String path3;
+	private static String path5;
 	private static String path6;
 	private static String path8;
+
 
 	@BeforeClass
 	public static void readPath() throws FileNotFoundException {
 		path1 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-1";
 		path2 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-2";
 		path3 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-3";
+		path5 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-5";
 		path6 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-6";
 		path8 = GitRepositoryTest.class.getResource("/").getPath() + "../../test-repos/git-8";
 	}
@@ -59,6 +64,7 @@ public class GitRepositoryTest {
 		git1 = new GitRepository(path1);
 		git2 = new GitRepository(path2);
 		git3 = new GitRepository(path3);
+		git5 = new GitRepository(path5);
 		git6 = new GitRepository(path6, true);
 		git8 = new GitRepository(path8);
 	}
@@ -308,6 +314,19 @@ public class GitRepositoryTest {
 		Modification third = modifications.get(2);
 		Assert.assertEquals(ModificationType.ADD, third.getType());
 		Assert.assertEquals(52, third.getAdded());
+	}
+
+	@Test
+	public void parentCommits() {
+		Commit mergeCommit = git5.getCommit("5d9d79607d7e82b6f236aa29be4ba89a28fb4f15");
+		Assert.assertEquals(2, mergeCommit.getParents().size());
+		Assert.assertTrue(mergeCommit.getParents().contains("fa8217c324e7fb46c80e1ddf907f4e141449637e"));
+		Assert.assertTrue(mergeCommit.getParents().contains("ff663cf1931a67d5e47b75fc77dcea432c728052"));
+
+		Commit normalCommit = git5.getCommit("ff663cf1931a67d5e47b75fc77dcea432c728052");
+		Assert.assertEquals(1, normalCommit.getParents().size());
+		Assert.assertTrue(normalCommit.getParents().contains("4a17f31c0d1285477a3a467d0bc3cb38e775097d"));
+
 	}
 	
 	@Test


### PR DESCRIPTION
This PR provides `Commit`s with both parents in case the commit is a merge. `Commit` now has a `getParents()` which returns a list of String hashes. The `getParent()` is still there for backwards compatibility. 

This tackles #51 , as asked by @ttben. 