### PR TITLE
bug: fix error in bookkeeping

### DIFF
--- a/src/main/java/org/repodriller/RepositoryMining.java
+++ b/src/main/java/org/repodriller/RepositoryMining.java
@@ -372,11 +372,15 @@ public class RepositoryMining {
 					ChangeSet cs = null;
 					try {
 						cs = csQueue.remove();
-						processChangeSet(repo, cs);
-						nConsumed++;
-					} catch (NoSuchElementException e) {
+					}
+					catch (NoSuchElementException e) {
 						log.debug("No ChangeSets left to process, must be done with this repo");
 						break;
+					}
+					nConsumed++;
+
+					try {
+						processChangeSet(repo, cs);
 					} catch (OutOfMemoryError e) {
 						String msg = "ChangeSet " + cs.getId() + " in " + repo.getLastDir() + " caused OOME:" + e + "\n\nGoodbye :/";
 						System.err.println(msg);
@@ -388,7 +392,7 @@ public class RepositoryMining {
 						continue;
 					}
 				}
-				log.debug("Thread done");
+				log.debug("Thread done: consumed " + nConsumed);
 				return nConsumed;
 			}));
 		}

--- a/src/test/java/org/repodriller/integration/ThrowingTest.java
+++ b/src/test/java/org/repodriller/integration/ThrowingTest.java
@@ -1,0 +1,32 @@
+package org.repodriller.integration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.repodriller.RepositoryMining;
+import org.repodriller.filter.range.Commits;
+import org.repodriller.scm.GitRepository;
+
+public class ThrowingTest {
+
+	private String path;
+
+	@Before
+	public void setUp() {
+		this.path = this.getClass().getResource("/").getPath() + "../../test-repos/git-4";
+	}
+
+	@Test
+	public void visitWhileVisitorThrows() {
+		ThrowingTestVisitor visitor = new ThrowingTestVisitor();
+
+		new RepositoryMining()
+		.in(GitRepository.singleProject(path))
+		.through(Commits.all())
+		.process(visitor)
+		.mine();
+
+		// Hope nothing went wrong.
+		return;
+	}
+
+}

--- a/src/test/java/org/repodriller/integration/ThrowingTestVisitor.java
+++ b/src/test/java/org/repodriller/integration/ThrowingTestVisitor.java
@@ -1,0 +1,53 @@
+package org.repodriller.integration;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.repodriller.RepoDrillerException;
+import org.repodriller.domain.Commit;
+import org.repodriller.persistence.PersistenceMechanism;
+import org.repodriller.scm.CommitVisitor;
+import org.repodriller.scm.SCMRepository;
+
+/**
+ * Same as TSTestVisitor but throws every time it visits.
+ */
+public class ThrowingTestVisitor implements CommitVisitor {
+
+	private List<String> visitedHashes;
+	private List<Calendar> visitedTimes;
+	private List<Commit> visitedCommits;
+
+	public ThrowingTestVisitor() {
+		visitedHashes = new ArrayList<>();
+		visitedTimes = new ArrayList<>();
+		visitedCommits = new ArrayList<>();
+	}
+
+	@Override
+	public void process(SCMRepository repo, Commit commit, PersistenceMechanism writer) throws RepoDrillerException {
+		visitedHashes.add(commit.getHash());
+		visitedTimes.add(commit.getDate());
+		visitedCommits.add(commit);
+		throw new RepoDrillerException("Grumpy visitor!");
+	}
+
+	@Override
+	public String name() {
+		return "test";
+	}
+
+	public List<String> getVisitedHashes() {
+		return visitedHashes;
+	}
+
+	public List<Calendar> getVisitedTimes() {
+		return visitedTimes;
+	}
+
+	public List<Commit> getVisitedCommits() {
+		return visitedCommits;
+	}
+
+}


### PR DESCRIPTION
# Problem
There is a bookkeeping assert for the threaded processing of ChangeSets.
The assert ensures that some thread attempted to work on every ChangeSet.

However, the per-thread counter is only incremented after attempting `processChangeSet`.
If `processChangeSet` throws an exception, the counter is not incremented.

The bookkeeping assert fails, but it should not because we still attempted
to work on the ChangeSet.

# Solution
Increment the counter before we `processChangeSet`.

# Test
1. This commit introduces a test for the case where a Visitor throws.
   It turns out that this case is innocuous because these are caught
	 by `RepoVisitor::visitCommit` and not thrown by `processChangeSet`.
2. You can, however, cause `processChangeSet` to throw by modifying
   the commit limits in `GitRepository`:

```java
private static final int MAX_SIZE_OF_A_DIFF = 100000;
private static final int DEFAULT_MAX_NUMBER_OF_FILES_IN_A_COMMIT = 5000;
```

This is concerning and should be addressed elsewhere.

# Fix for
#118.