### PR TITLE
Same behavior as Git Log

### DIFF
--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -215,7 +215,7 @@ public class GitRepository implements SCM {
 	private List<ChangeSet> getAllCommits(Git git) throws GitAPIException, IOException {
 		List<ChangeSet> allCs = new ArrayList<>();
 
-		for (RevCommit r : git.log().all().call()) {
+		for (RevCommit r : git.log().call()) {
 			allCs.add(extractChangeSet(r));
 		}
 		return allCs;

--- a/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
@@ -147,8 +147,8 @@ public class GitRepositoryTest {
 	public void shouldGetAllCommits() {
 		List<ChangeSet> cs = git1.getChangeSets();
 		
-		Assert.assertEquals(14, cs.size());
-		Assert.assertEquals("a997e9d400f742003dea601bb05a9315d14d1124", cs.get(0).getId());
+		Assert.assertEquals(13, cs.size());
+		Assert.assertEquals("e7d13b0511f8a176284ce4f92ed8c6e8d09c77f2", cs.get(0).getId());
 		Assert.assertEquals("866e997a9e44cb4ddd9e00efe49361420aff2559", cs.get(13).getId());
 	}
 	

--- a/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
+++ b/src/test/java/org/repodriller/scm/git/GitRepositoryTest.java
@@ -149,7 +149,7 @@ public class GitRepositoryTest {
 		
 		Assert.assertEquals(13, cs.size());
 		Assert.assertEquals("e7d13b0511f8a176284ce4f92ed8c6e8d09c77f2", cs.get(0).getId());
-		Assert.assertEquals("866e997a9e44cb4ddd9e00efe49361420aff2559", cs.get(13).getId());
+		Assert.assertEquals("866e997a9e44cb4ddd9e00efe49361420aff2559", cs.get(12).getId());
 	}
 	
 	@Test


### PR DESCRIPTION
RepoDriller was using `git.log().all().call()` which forces Git to show all commits, even ones that may not belong to any branch. Git does not do it by default. 

In JGit, we should do only `git.log().call()`. This is a *breaking change* for RepoDriller (meaning that previous executions may show a different result), but I suppose a good one.