### PR TITLE
Using function extractChangeSet in getHead

### DIFF
--- a/src/main/java/org/repodriller/scm/GitRepository.java
+++ b/src/main/java/org/repodriller/scm/GitRepository.java
@@ -156,7 +156,7 @@ public class GitRepository implements SCM {
 
 			revWalk = new RevWalk(git.getRepository());
 			RevCommit r = revWalk.parseCommit(head);
-			return new ChangeSet(r.getName(), convertToDate(r));
+			return extractChangeSet(r);
 
 		} catch (Exception e) {
 			throw new RuntimeException("error in getHead() for " + path, e);


### PR DESCRIPTION
There exist a function called extractChangeSet that returns a ChangeSet given a RevCommit. Using it in getHead for consistency